### PR TITLE
Plugin Imports: ensure stable output of imports for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# protoc-gen-star (PGS) [![Build Status](https://travis-ci.com/lyft/protoc-gen-star.svg?token=XXXXXX&branch=master)][travis]
+# protoc-gen-star (PGS) [![Build Status](https://travis-ci.org/lyft/protoc-gen-star.svg?branch=master)](https://travis-ci.org/lyft/protoc-gen-star)
 
 **!!! THIS PROJECT IS A WORK-IN-PROGRESS | THE API SHOULD BE CONSIDERED UNSTABLE !!!**
 


### PR DESCRIPTION
This patch ensures that the `GenerateImports` output from `PluginBase` is stably sorted, using `text/template` instead of iterating over the import map. 