### PR TITLE
Pin protoc-gen-go version < 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
-go: 1.8
+go: 1.10
 
 env:
   global:
-    - GLIDE_VER="v0.12.3"
+    - GLIDE_VER="v0.13.1"
     - GLIDE_ARCH="linux-amd64"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.10
+go: "1.10"
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install: # downloads dependencies (including test deps) for the package
 
 .PHONY: lint
 lint: # lints the package for common code smells
-	which golint || go get -u github.com/golang/lint/golint
+	which golint || go get -u golang.org/x/lint/golint
 	test -z "$(gofmt -d -s ./*.go)" || (gofmt -d -s ./*.go && exit 1)
 	golint -set_exit_status
 	go tool vet -all -shadow -shadowstrict *.go

--- a/glide.lock
+++ b/glide.lock
@@ -1,40 +1,40 @@
-hash: 35904b77dd8e9988b31d00bfc5dbe6434abafbe1441140238820203de9bc637e
-updated: 2017-06-13T18:06:31.373813246-07:00
+hash: 6ea51c7c237894b7b7f30005f6b9f754c79d7c6c21672c4ec220b4fbc6f06673
+updated: 2018-05-09T11:18:54.306177-07:00
 imports:
 - name: github.com/golang/protobuf
-  version: c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
+  version: 925541529c1fa6821df4e44ce2723319eb2be768
   subpackages:
   - proto
   - protoc-gen-go/descriptor
   - protoc-gen-go/generator
   - protoc-gen-go/plugin
 - name: github.com/spf13/afero
-  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
+  version: 63644898a8da0bc22138abf860edaf5277b6102e
   subpackages:
   - mem
 - name: golang.org/x/net
-  version: bb807669a61aca6092d8137da1fab2150bb96ad7
+  version: 2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1
   subpackages:
   - context
 - name: golang.org/x/sync
-  version: f52d1811a62927559de87708c8913c1650ce4f26
+  version: 1d60e4601c6fd243af51cc01ddf169918a5407ca
   subpackages:
   - errgroup
 - name: golang.org/x/text
-  version: f4b4367115ec2de254587813edaa901bc1c723a8
+  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
   subpackages:
   - transform
   - unicode/norm
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 87df7c60d5820d0f8ae11afede5aa52325c09717
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: a726187e3128d0a0ec37f73ca7c4d3e508e6c2e5
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/lyft/protoc-gen-star
 import:
 - package: github.com/golang/protobuf
+  version: < v1.1.0
 - package: github.com/spf13/afero
 - package: golang.org/x/text
 - package: golang.org/x/sync


### PR DESCRIPTION
This patch pins the current code to protoc-gen-go < v1.1.0 as that version introduces a breaking change. This change effectively bumps the PGG dep to v1.0.0.

See #13 for context. A later patch will provide support for PGG >= v1.1.0