### PR TITLE
Bazel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 vendor/
 testdata/generated/
 
+.idea/**
+
+/bazel-*
+
 # coverage reports
 cover.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ install: make install
 script:
   - make lint tests
   - ${BAZEL_BIN} test --verbose_failures --test_output=errors --noshow_progress //:all_tests
+
+after_script:
+  - ${BAZEL_BIN} shutdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,7 @@ before_install:
   - tar -xvf /tmp/glide.tar.gz --strip-components 1 -C ${GOPATH}/bin
 
 install: make install
-script: make lint tests
+
+script:
+  - make lint tests
+  - bazel test --verbose_failures --test_output=errors --noshow_progress //:all_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,17 @@ env:
   global:
     - GLIDE_VER="v0.13.1"
     - GLIDE_ARCH="linux-amd64"
+    - BAZEL_VERSION="0.16.0"
+    - BAZEL_BIN="${GOPATH}/bin/bazel"
 
 before_install:
   - mkdir -p $GOPATH/bin
   - wget "https://github.com/Masterminds/glide/releases/download/${GLIDE_VER}/glide-${GLIDE_VER}-${GLIDE_ARCH}.tar.gz" -O /tmp/glide.tar.gz
   - tar -xvf /tmp/glide.tar.gz --strip-components 1 -C ${GOPATH}/bin
+  - wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64" -O ${BAZEL_BIN} && chmod +x ${BAZEL_BIN}
 
 install: make install
 
 script:
   - make lint tests
-  - bazel test --verbose_failures --test_output=errors --noshow_progress //:all_tests
+  - ${BAZEL_BIN} test --verbose_failures --test_output=errors --noshow_progress //:all_tests

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,13 @@ gazelle(
     prefix = "github.com/lyft/protoc-gen-star",
 )
 
+test_suite(
+    name = "all_tests",
+    tests = [
+        ":go_default_test"
+    ]
+)
+
 go_library(
     name = "go_default_library",
     srcs = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,116 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:exclude testdata
+gazelle(
+    name = "gazelle",
+    external = "external",
+    prefix = "github.com/lyft/protoc-gen-star",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "artifact.go",
+        "build_context.go",
+        "comment.go",
+        "debug.go",
+        "docs.go",
+        "entity.go",
+        "enum.go",
+        "enum_value.go",
+        "extension.go",
+        "field.go",
+        "field_type.go",
+        "field_type_elem.go",
+        "file.go",
+        "gatherer.go",
+        "generator.go",
+        "init_option.go",
+        "message.go",
+        "method.go",
+        "module.go",
+        "name.go",
+        "node.go",
+        "oneof.go",
+        "package.go",
+        "parameters.go",
+        "path.go",
+        "persister.go",
+        "plugin.go",
+        "post_process.go",
+        "proto.go",
+        "protoc_gen_go.go",
+        "service.go",
+        "workflow.go",
+        "workflow_multipackage.go",
+    ],
+    importpath = "github.com/lyft/protoc-gen-star",
+    visibility = ["//visibility:public"],
+    # Keep referencing the plugin and descriptor libraries directly. using the WKT's declared in `io_bazel_rules_go`
+    # causes problems.
+    # gazelle will prefer these by default.
+    #   "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
+    #   "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+    #keep
+    deps = [
+        "@com_github_golang_protobuf//descriptor:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/plugin:go_default_library",
+        "@com_github_spf13_afero//:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "artifact_test.go",
+        "build_context_test.go",
+        "comment_test.go",
+        "debug_test.go",
+        "enum_test.go",
+        "enum_value_test.go",
+        "extension_test.go",
+        "field_test.go",
+        "field_type_elem_test.go",
+        "field_type_test.go",
+        "file_test.go",
+        "gatherer_test.go",
+        "generator_test.go",
+        "init_option_test.go",
+        "message_test.go",
+        "method_test.go",
+        "module_test.go",
+        "name_test.go",
+        "node_nilvisitor_test.go",
+        "node_passvisitor_test.go",
+        "node_test.go",
+        "oneof_test.go",
+        "package_test.go",
+        "parameters_test.go",
+        "path_test.go",
+        "persister_test.go",
+        "plugin_test.go",
+        "post_process_test.go",
+        "proto_test.go",
+        "protoc_gen_go_test.go",
+        "service_test.go",
+        "workflow_multipackage_test.go",
+        "workflow_test.go",
+    ],
+    embed = [":go_default_library"],
+    # see comment above
+    #keep
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/generator:go_default_library",
+        "@com_github_golang_protobuf//protoc-gen-go/plugin:go_default_library",
+        "@com_github_spf13_afero//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
     ],
     importpath = "github.com/lyft/protoc-gen-star",
     visibility = ["//visibility:public"],
+    # https://github.com/bazelbuild/rules_go/issues/1629
     # Keep referencing the plugin and descriptor libraries directly. using the WKT's declared in `io_bazel_rules_go`
     # causes problems.
     # gazelle will prefer these by default.
@@ -110,7 +111,7 @@ go_test(
         "workflow_test.go",
     ],
     embed = [":go_default_library"],
-    # see comment above
+    # see comment on :go_default_library
     #keep
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,8 +11,8 @@ gazelle(
 test_suite(
     name = "all_tests",
     tests = [
-        ":go_default_test"
-    ]
+        ":go_default_test",
+    ],
 )
 
 go_library(
@@ -73,6 +73,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "artifact_test.go",
         "build_context_test.go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,51 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+)
+http_archive(
+    name = "bazel_gazelle",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.13.0/bazel-gazelle-0.13.0.tar.gz"],
+    sha256 = "bc653d3e058964a5a26dcad02b6c72d7d63e6bb88d94704990b908a1445b8758",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+go_rules_dependencies()
+go_register_toolchains()
+gazelle_dependencies()
+
+# protobuf, x_text and x_net are allready exported by the go rules.
+
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    commit = "346938d642f2ec3594ed81d874461961cd0faa76",
+    importpath = "github.com/davecgh/go-spew",
+)
+
+go_repository(
+    name = "com_github_pmezard_go_difflib",
+    commit = "792786c7400a136282c1664665ae0a8db921c6c2",
+    importpath = "github.com/pmezard/go-difflib",
+)
+
+go_repository(
+    name = "com_github_spf13_afero",
+    commit = "63644898a8da0bc22138abf860edaf5277b6102e",
+    importpath = "github.com/spf13/afero",
+)
+
+go_repository(
+    name = "com_github_stretchr_testify",
+    commit = "a726187e3128d0a0ec37f73ca7c4d3e508e6c2e5",
+    importpath = "github.com/stretchr/testify",
+)
+
+go_repository(
+    name = "org_golang_x_sync",
+    commit = "1d60e4601c6fd243af51cc01ddf169918a5407ca",
+    importpath = "golang.org/x/sync",
+)
+


### PR DESCRIPTION
The build picks up the protobuf, x_net and x_texts packages from rules_go the rest of the packages are declared in the workspace file. 