### PR TITLE
Add ServerStream method to pgsgo context

### DIFF
--- a/lang/go/context.go
+++ b/lang/go/context.go
@@ -34,6 +34,11 @@ type Context interface {
 	// ClientName returns the name of the client interface for the Service.
 	ClientName(service pgs.Service) pgs.Name
 
+	// ServerStream returns the name of the grpc.ServerStream wrapper for this
+	// method. This name is only used if client or server streaming is
+	// implemented for this method.
+	ServerStream(method pgs.Method) pgs.Name
+
 	// OneofOption returns the struct name that wraps a OneOf option's value. These
 	// messages contain one field, matching the value returned by Name for this
 	// Field.

--- a/lang/go/name.go
+++ b/lang/go/name.go
@@ -20,21 +20,21 @@ func (c context) Name(node pgs.Node) pgs.Name {
 	case pgs.File: // the package name for this file
 		return c.PackageName(en)
 	case ChildEntity: // Message or Enum types, which may be nested
-		n := pggUpperCamelCase(en.Name())
+		n := PGGUpperCamelCase(en.Name())
 		if p, ok := en.Parent().(pgs.Message); ok {
 			n = pgs.Name(joinNames(c.Name(p), n))
 		}
 		return n
 	case pgs.Field: // field names cannot conflict with other generated methods
-		return replaceProtected(pggUpperCamelCase(en.Name()))
+		return replaceProtected(PGGUpperCamelCase(en.Name()))
 	case pgs.OneOf: // oneof field names cannot conflict with other generated methods
-		return replaceProtected(pggUpperCamelCase(en.Name()))
+		return replaceProtected(PGGUpperCamelCase(en.Name()))
 	case pgs.EnumValue: // EnumValue are prefixed with the enum name
 		return pgs.Name(joinNames(c.Name(en.Enum()), en.Name()))
 	case pgs.Service: // always return the server name
 		return c.ServerName(en)
 	case pgs.Entity: // any other entity should be just upper-camel-cased
-		return pggUpperCamelCase(en.Name())
+		return PGGUpperCamelCase(en.Name())
 	default:
 		panic("unreachable")
 	}
@@ -45,16 +45,22 @@ func (c context) OneofOption(field pgs.Field) pgs.Name {
 }
 
 func (c context) ServerName(s pgs.Service) pgs.Name {
-	n := pggUpperCamelCase(s.Name())
+	n := PGGUpperCamelCase(s.Name())
 	return pgs.Name(fmt.Sprintf("%sServer", n))
 }
 
 func (c context) ClientName(s pgs.Service) pgs.Name {
-	n := pggUpperCamelCase(s.Name())
+	n := PGGUpperCamelCase(s.Name())
 	return pgs.Name(fmt.Sprintf("%sClient", n))
 }
 
-// pggUpperCamelCase converts Name n to the protoc-gen-go defined upper
+func (c context) ServerStream(m pgs.Method) pgs.Name {
+	s := PGGUpperCamelCase(m.Service().Name())
+	n := PGGUpperCamelCase(m.Name())
+	return joinNames(s, n) + "Server"
+}
+
+// PGGUpperCamelCase converts Name n to the protoc-gen-go defined upper
 // camelcase. The rules are slightly different from pgs.UpperCamelCase in that
 // leading underscores are converted to 'X', mid-string underscores followed by
 // lowercase letters are removed and the letter is capitalized, all other
@@ -63,7 +69,7 @@ func (c context) ClientName(s pgs.Service) pgs.Name {
 // names).
 //
 // See: https://godoc.org/github.com/golang/protobuf/protoc-gen-go/generator#CamelCase
-func pggUpperCamelCase(n pgs.Name) pgs.Name {
+func PGGUpperCamelCase(n pgs.Name) pgs.Name {
 	return pgs.Name(generator.CamelCase(n.String()))
 }
 

--- a/lang/go/name_test.go
+++ b/lang/go/name_test.go
@@ -24,7 +24,7 @@ func TestPGGUpperCamelCase(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		assert.Equal(t, tc.ex, pggUpperCamelCase(pgs.Name(tc.in)).String())
+		assert.Equal(t, tc.ex, PGGUpperCamelCase(pgs.Name(tc.in)).String())
 	}
 }
 
@@ -199,6 +199,34 @@ func TestContext_ClientName(t *testing.T) {
 			require.True(t, ok, "could not find service")
 			s := e.(pgs.Service)
 			assert.Equal(t, tc.expected, ctx.ClientName(s))
+		})
+	}
+}
+
+func TestContext_ServerStream(t *testing.T) {
+	t.Parallel()
+
+	ast := buildGraph(t, "names", "entities")
+	ctx := loadContext(t, "names", "entities")
+
+	tests := []struct {
+		method   string
+		expected pgs.Name
+	}{
+		{"UpperCamel", "Service_UpperCamelServer"},
+		{"lowerCamel", "Service_LowerCamelServer"},
+		{"lower_snake", "Service_LowerSnakeServer"},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.method, func(t *testing.T) {
+			t.Parallel()
+
+			e, ok := ast.Lookup(".names.entities.Service." + tc.method)
+			require.True(t, ok, "could not find method")
+			m := e.(pgs.Method)
+			assert.Equal(t, tc.expected, ctx.ServerStream(m))
 		})
 	}
 }


### PR DESCRIPTION
This patch adds the ServerStream helper to pgsgo.Context to enable resolving the grpc.ServerStream wrapper for client/server/bidi streaming methods. It also exports the PGGUpperCamelCase function for camel-casing following the same pattern as protoc-gen-go.