### PR TITLE
bad chars in go_package name

### DIFF
--- a/lang/go/name_test.go
+++ b/lang/go/name_test.go
@@ -35,8 +35,8 @@ func TestName(t *testing.T) {
 	ctx := loadContext(t, "names", "entities")
 
 	f := ast.Targets()["entities.proto"]
-	assert.Equal(t, pgs.Name("entities"), ctx.Name(f))
-	assert.Equal(t, pgs.Name("entities"), ctx.Name(f.Package()))
+	assert.Equal(t, pgs.Name("BAD_pack__age_name_"), ctx.Name(f))
+	assert.Equal(t, pgs.Name("BAD_pack__age_name_"), ctx.Name(f.Package()))
 
 	assert.Panics(t, func() {
 		ctx.Name(nil)

--- a/lang/go/package.go
+++ b/lang/go/package.go
@@ -90,5 +90,7 @@ func (c context) optionPackage(e pgs.Entity) (path, pkg string) {
 		return
 	}
 
+	pkg = nonAlphaNumPattern.ReplaceAllString(pkg, "_")
+
 	return
 }

--- a/lang/go/testdata/names/entities/entities.proto
+++ b/lang/go/testdata/names/entities/entities.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package names.entities;
-option go_package = "entities";
+option go_package = "BAD.pack--age.name$";
 
 message UpperCamelCaseMessage {}
 


### PR DESCRIPTION
protoc-gen-go replaces all bad characters in the go_package option to underscores. This patch fixes that behavior in the pgsgo.Context.