### PR TITLE
Nested Messages/Enums/Values edge-case behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 PKG  := $(shell go list .)
 PKGS := $(shell go list ./...)
 
+.PHONY: bootstrap
+bootstrap: vendor testdata # set up the project for development
+
 .PHONY: lint
 lint: # lints the package for common code smells
 	set -e; for f in `find . -name "*.go" -not -name "*.pb.go" | grep -v vendor`; do \

--- a/lang/go/name_test.go
+++ b/lang/go/name_test.go
@@ -63,6 +63,7 @@ func TestName(t *testing.T) {
 		{"Nested._underscore", "Nested_XUnderscore"},
 		{"Nested.String", "Nested_String"},
 		{"Nested.Message.Message", "Nested_Message_Message"},
+		{"Nested.lowerMsg", "NestedLowerMsg"},
 
 		// Enums
 		{"UpperCamelCaseEnum", "UpperCamelCaseEnum"},
@@ -84,9 +85,11 @@ func TestName(t *testing.T) {
 
 		// Nested Enums
 		{"Nested.Enum", "Nested_Enum"},
-		{"Nested.Enum.VALUE", "Nested_Enum_VALUE"},
+		{"Nested.Enum.VALUE", "Nested_VALUE"},
 		{"Nested.Message.Enum", "Nested_Message_Enum"},
-		{"Nested.Message.Enum.VALUE", "Nested_Message_Enum_VALUE"},
+		{"Nested.Message.Enum.NESTED", "Nested_Message_NESTED"},
+		{"Nested.lowercase", "NestedLowercase"},
+		{"Nested.lowercase.lower", "Nested_lower"},
 
 		// Field Names
 		{"Fields.lower_snake_case", "LowerSnakeCase"},

--- a/lang/go/testdata/names/entities/entities.proto
+++ b/lang/go/testdata/names/entities/entities.proto
@@ -27,7 +27,7 @@ message Nested {
     message Message {
         message Message {}
 
-        enum Enum { VALUE = 0; }
+        enum Enum { NESTED = 0; }
     }
 
     message _underscore {}
@@ -35,6 +35,10 @@ message Nested {
     message String {} // protected name
 
     enum Enum { VALUE = 0; }
+
+    enum lowercase { lower = 0; }
+
+    message lowerMsg {}
 }
 
 enum UpperCamelCaseEnum {


### PR DESCRIPTION
This patch addresses unusual edge-case behavior in generated Go code for nested messages, enums, and enum values.

If a nested message/enum name begins with a lowercase, the generated struct will not separate the parent from the child name:

```proto
message Foo {
   message Bar {}
   message baz {}
}
```

results in the following structs:

```go
type Foo struct {}
type Foo_Bar struct {}
type FooBaz struct {}
```

----

While values of root enums in a file are prefixed with the enum's name, enum values nested within a message are prefixed with the message name:

```proto
enum Foo {
  FIZZ = 0;
}

message Bar {
  enum Baz {
    BUZZ = 0;
  }
}
```

results in the following `consts`:

```go
const Foo_FIZZ Foo = 0
const Bar_BUZZ Bar_Baz = 0
```