### PR TITLE
Add `GeneratorError` Artifact, expose it to modules via ModuleBase

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -310,3 +310,13 @@ func cleanGeneratorFileName(name string) (string, error) {
 
 	return name, nil
 }
+
+// GeneratorError Artifacts are strings describing errors that happened in the
+// code generation, but have not been fatal. They'll be used to populate the
+// CodeGeneratorResponse's `error` field. Since that field is a string, multiple
+// GeneratorError Artifacts will be concatenated.
+type GeneratorError struct {
+	Artifact
+
+	Message string
+}

--- a/module.go
+++ b/module.go
@@ -256,4 +256,11 @@ func (m *ModuleBase) OverwriteCustomTemplateFile(name string, tpl Template, data
 	})
 }
 
+// AddError adds a string to the `errors` field of the created
+// CodeGeneratorResponse. Multiple calls to AddError will cause the errors to
+// be concatenated (separated by "; ").
+func (m *ModuleBase) AddError(message string) {
+	m.AddArtifact(GeneratorError{Message: message})
+}
+
 var _ Module = (*ModuleBase)(nil)

--- a/module_test.go
+++ b/module_test.go
@@ -272,3 +272,13 @@ func TestModuleBase_OverwriteCustomTemplateFile(t *testing.T) {
 		},
 	}, arts[0])
 }
+
+func TestModuleBase_AddError(t *testing.T) {
+	t.Parallel()
+
+	m := new(ModuleBase)
+	m.AddError("bohoo")
+	arts := m.Artifacts()
+	assert.Len(t, arts, 1)
+	assert.Equal(t, GeneratorError{Message: "bohoo"}, arts[0])
+}

--- a/persister.go
+++ b/persister.go
@@ -3,6 +3,7 @@ package pgs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/plugin"
@@ -83,6 +84,12 @@ func (p *stdPersister) Persist(arts ...Artifact) *plugin_go.CodeGeneratorRespons
 				a.Overwrite,
 				a.Perms,
 			)
+		case GeneratorError:
+			if resp.Error == nil {
+				resp.Error = proto.String(a.Message)
+				continue
+			}
+			resp.Error = proto.String(strings.Join([]string{resp.GetError(), a.Message}, "; "))
 		default:
 			p.Failf("unrecognized artifact type: %T", a)
 		}


### PR DESCRIPTION
This way, non-critical errors can be returned by calling m.AddError.

Fixes #34.