### PR TITLE
travis: fix building branches of PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go: "1.11"
+go_import_path: github.com/lyft/protoc-gen-star
 
 env:
   global:


### PR DESCRIPTION
When pushing a branch to my fork, a travis run will be kicked of, but
it'll fail -- since `github.com/<me>/protoc-gen-star` is nothing like
`github.com/lyft/protoc-gen-star`.

This addition to .travis.yml should fix this.

See [before 💥](https://travis-ci.com/srenatus/protoc-gen-star/builds/85390296) and [after ✅ ](https://travis-ci.com/srenatus/protoc-gen-star/builds/85390958) 😉 