### PR TITLE
go: go_package option overrides import_path parameter

### DIFF
--- a/lang/go/package.go
+++ b/lang/go/package.go
@@ -18,7 +18,9 @@ func (c context) PackageName(node pgs.Node) pgs.Name {
 
 	_, pkg := c.optionPackage(e)
 
-	if ip := c.p.Str("import_path"); ip != "" {
+	// use import_path parameter ONLY if there is no go_package option in the file.
+	if ip := c.p.Str("import_path"); ip != "" &&
+		e.File().Descriptor().GetOptions().GetGoPackage() == "" {
 		pkg = ip
 	}
 

--- a/lang/go/package_test.go
+++ b/lang/go/package_test.go
@@ -15,14 +15,15 @@ func TestPackageName(t *testing.T) {
 		dir      string
 		expected pgs.Name
 	}{
-		{"keyword", "_package"},        // go keywords are prefixed with _
-		{"none", "NO_pack__age_name_"}, // if there is no package or go_package option, use the input filepath
-		{"package", "my_package"},      // use the go_package option
-		{"unnamed", "names_unnamed"},   // use the proto package if no go_package
-		{"import", "bar"},              // uses the basename if go_package contains a /
-		{"override", "baz"},            // if go_package contains ;, use everything to the right
-		{"import_path", "_package"},    // import_path param used if no go_package option
-		{"mapped", "unaffected"},       // M mapped params are ignored for build targets
+		{"keyword", "_package"},              // go keywords are prefixed with _
+		{"none", "NO_pack__age_name_"},       // if there is no package or go_package option, use the input filepath
+		{"package", "my_package"},            // use the go_package option
+		{"unnamed", "names_unnamed"},         // use the proto package if no go_package
+		{"import", "bar"},                    // uses the basename if go_package contains a /
+		{"override", "baz"},                  // if go_package contains ;, use everything to the right
+		{"import_path", "_package"},          // import_path param used if no go_package option
+		{"mapped", "unaffected"},             // M mapped params are ignored for build targets
+		{"import_path_mapped", "go_package"}, // mixed import_path and M parameters should lose to go_package
 	}
 
 	for _, test := range tests {

--- a/lang/go/testdata/names/import_path_mapped/import_path_mapped.proto
+++ b/lang/go/testdata/names/import_path_mapped/import_path_mapped.proto
@@ -1,0 +1,5 @@
+syntax="proto3";
+package names.import_path_mapped;
+option go_package="go_package";
+
+message Mapped {}

--- a/lang/go/testdata/names/import_path_mapped/params
+++ b/lang/go/testdata/names/import_path_mapped/params
@@ -1,0 +1,1 @@
+Mnames/import_path_mapped/import_path_mapped.proto=github.com/foo/bar,import_path=github.com/fizz/buzz


### PR DESCRIPTION
If the `import_path` param, `M` mapping param and `go_package` option are all set, the `go_package` option determines the name of the package. This patch fixes incorrect behavior here where import_path was overriding the value.