### PR TITLE
go: name collisions with oneof fields and nested messages/enums

### DIFF
--- a/lang/go/name.go
+++ b/lang/go/name.go
@@ -45,7 +45,21 @@ func (c context) Name(node pgs.Node) pgs.Name {
 }
 
 func (c context) OneofOption(field pgs.Field) pgs.Name {
-	return pgs.Name(joinNames(c.Name(field.Message()), c.Name(field)))
+	n := pgs.Name(joinNames(c.Name(field.Message()), c.Name(field)))
+
+	for _, msg := range field.Message().Messages() {
+		if c.Name(msg) == n {
+			return n + "_"
+		}
+	}
+
+	for _, en := range field.Message().Enums() {
+		if c.Name(en) == n {
+			return n + "_"
+		}
+	}
+
+	return n
 }
 
 func (c context) ServerName(s pgs.Service) pgs.Name {

--- a/lang/go/name_test.go
+++ b/lang/go/name_test.go
@@ -57,6 +57,8 @@ func TestName(t *testing.T) {
 		{"_underscore", "XUnderscore"},
 		{"__DoubleUnderscore", "X_DoubleUnderscore"},
 		{"String", "String"},
+		{"MsgWith3dInside", "MsgWith3DInside"},
+		{"MsgEndsWith3d", "MsgEndsWith3D"},
 
 		// Nested Messages
 		{"Nested.Message", "Nested_Message"},
@@ -159,6 +161,8 @@ func TestContext_OneofOption(t *testing.T) {
 		{"lowerCamelCaseO", "Oneofs_LowerCamelCaseO"},
 		{"UpperCamelCaseO", "Oneofs_UpperCamelCaseO"},
 		{"reset", "Oneofs_Reset_"},
+		{"some_msg", "Oneofs_SomeMsg_"},
+		{"some_enum", "Oneofs_SomeEnum_"},
 	}
 
 	for _, test := range tests {

--- a/lang/go/testdata/names/entities/entities.proto
+++ b/lang/go/testdata/names/entities/entities.proto
@@ -88,6 +88,13 @@ message Oneofs {
         bool UpperCamelCaseO = 11;
         bool reset = 12; // protected
     }
+
+    message SomeMsg {}
+    enum SomeEnum { VALUE = 0; }
+    oneof some_msg_oneof {
+        SomeMsg some_msg = 13;
+        SomeEnum some_enum = 14;
+    }
 }
 
 service UpperCamelService {}
@@ -110,3 +117,8 @@ service Service {
     rpc SCREAMING_SNAKE(String) returns (String);
     rpc Reset(String) returns (String);
 }
+
+message MsgWith3dInside {}
+
+message MsgEndsWith3d {}
+


### PR DESCRIPTION
This patch addresses the following case in Go. Given the following protos:

```proto
message Foo {
  message Bar {}
  enum Baz { VALUE = 0; }

  oneof some_oneof {
    bool bar = 1;
    int32 baz = 2;
  }
}
```

The `some_oneof` field on the generated struct will have an interface type that is satisfied by two wrapper classes around the `bar` and `baz` fields typically named `Foo_Bar` and `Foo_Baz`, respectively. However, because there are a nested message and enum with those same names, the oneof wrappers' names should be suffixed with an underscore: `Foo_Bar_` and `Foo_Baz_`. 