### PR TITLE
go_package: resolve package name transitively from other files in same execution

### DIFF
--- a/lang/go/Makefile
+++ b/lang/go/Makefile
@@ -4,6 +4,7 @@ testdata-names: ../../bin/protoc-gen-debug # parse the proto file sets in testda
 	set -e; for subdir in `find . -type d -mindepth 1 -maxdepth 1`; do \
 		cd $$subdir; \
 		params=`cat params`; \
+		echo $$params; \
 		protoc -I . \
 			--plugin=protoc-gen-debug=../../../../../bin/protoc-gen-debug \
 			--debug_out=".:." \

--- a/lang/go/Makefile
+++ b/lang/go/Makefile
@@ -4,7 +4,6 @@ testdata-names: ../../bin/protoc-gen-debug # parse the proto file sets in testda
 	set -e; for subdir in `find . -type d -mindepth 1 -maxdepth 1`; do \
 		cd $$subdir; \
 		params=`cat params`; \
-		echo $$params; \
 		protoc -I . \
 			--plugin=protoc-gen-debug=../../../../../bin/protoc-gen-debug \
 			--debug_out=".:." \

--- a/lang/go/package.go
+++ b/lang/go/package.go
@@ -103,7 +103,9 @@ func (c context) resolveGoPackageOption(e pgs.Entity) string {
 		return pkg
 	}
 
-	// protoc-gen-go will use the go_package option from _any_ file in the same execution since it's assumed that
+	// protoc-gen-go will use the go_package option from _any_ file in the same
+	// execution since it's assumed that all the files are in the same Go
+	// package. PG* will only verify this against files in the same proto package
 	for _, f := range e.Package().Files() {
 		if pkg := f.Descriptor().GetOptions().GetGoPackage(); pkg != "" {
 			return pkg

--- a/lang/go/package.go
+++ b/lang/go/package.go
@@ -65,7 +65,7 @@ func (c context) optionPackage(e pgs.Entity) (path, pkg string) {
 	}
 
 	// check if there's a go_package option specified
-	pkg = e.File().Descriptor().GetOptions().GetGoPackage()
+	pkg = c.resolveGoPackageOption(e)
 	path = e.File().InputPath().Dir().String()
 
 	if pkg == "" {
@@ -95,4 +95,20 @@ func (c context) optionPackage(e pgs.Entity) (path, pkg string) {
 	pkg = nonAlphaNumPattern.ReplaceAllString(pkg, "_")
 
 	return
+}
+
+func (c context) resolveGoPackageOption(e pgs.Entity) string {
+	// attempt to get it from the current file
+	if pkg := e.File().Descriptor().GetOptions().GetGoPackage(); pkg != "" {
+		return pkg
+	}
+
+	// protoc-gen-go will use the go_package option from _any_ file in the same execution since it's assumed that
+	for _, f := range e.Package().Files() {
+		if pkg := f.Descriptor().GetOptions().GetGoPackage(); pkg != "" {
+			return pkg
+		}
+	}
+
+	return ""
 }

--- a/lang/go/package_test.go
+++ b/lang/go/package_test.go
@@ -24,6 +24,7 @@ func TestPackageName(t *testing.T) {
 		{"import_path", "_package"},          // import_path param used if no go_package option
 		{"mapped", "unaffected"},             // M mapped params are ignored for build targets
 		{"import_path_mapped", "go_package"}, // mixed import_path and M parameters should lose to go_package
+		{"transitive_package", "foobar"},     // go_option gets picked up from other files if present
 	}
 
 	for _, test := range tests {

--- a/lang/go/testdata/names/import_path_mapped/params
+++ b/lang/go/testdata/names/import_path_mapped/params
@@ -1,1 +1,1 @@
-Mnames/import_path_mapped/import_path_mapped.proto=github.com/foo/bar,import_path=github.com/fizz/buzz
+Mimport_path_mapped.proto=github.com/foo/bar,import_path=github.com/fizz/buzz

--- a/lang/go/testdata/names/transitive_package/other.proto
+++ b/lang/go/testdata/names/transitive_package/other.proto
@@ -1,0 +1,8 @@
+syntax="proto3";
+package names.transitive_package;
+
+option go_package="foobar";
+
+message Other {
+    bool value = 1;
+}

--- a/lang/go/testdata/names/transitive_package/params
+++ b/lang/go/testdata/names/transitive_package/params
@@ -1,0 +1,1 @@
+Mmapped.proto=example.com/foo/bar,Mmapped_no_options/mapped.proto=example.com/fizz/buzz,Mnames/mapped_no_options/mapped.proto=example.com/quux/baz

--- a/lang/go/testdata/names/transitive_package/transitive.proto
+++ b/lang/go/testdata/names/transitive_package/transitive.proto
@@ -1,0 +1,6 @@
+syntax="proto3";
+package names.transitive_package;
+
+message Transitive {
+    bool value = 1;
+}


### PR DESCRIPTION
protoc-gen-go can only operate against a single (go) package's proto files at the same time, so is able to resolve the `go_package` option off of any file to apply it to all files in the same execution (it likely assumes they are all the same and probably checks it during its code generation).

This patch adds this behavior to PG*'s go-specific tooling, but will only check the files in the same proto package for a go_package option since PG* is not limited to running against a single package.