### PR TITLE
protoc-gen-debug: create dir before writing file

### DIFF
--- a/protoc-gen-debug/main.go
+++ b/protoc-gen-debug/main.go
@@ -31,8 +31,13 @@ func main() {
 		log.Fatal(`please execute the plugin with the output path to properly write the output file: --debug_out="{PATH}:{PATH}"`)
 	}
 
+	err = os.MkdirAll(path, 0755)
+	if err != nil {
+		log.Fatal("unable to create output dir: ", err)
+	}
+
 	err = ioutil.WriteFile(filepath.Join(path, "code_generator_request.pb.bin"), data, 0644)
-	if path == "" {
+	if err != nil {
 		log.Fatal("unable to write request to disk: ", err)
 	}
 


### PR DESCRIPTION
This patch fixes PGD to properly write a file into a directory that does not exist. Also fixes erroneous error handling that wasn't checking the result of the output file being written.