### PR TITLE
AST: special case packageless (root) entity FQNs

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -2,7 +2,7 @@ package pgs
 
 import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
 // AST encapsulates the entirety of the input CodeGeneratorRequest from protoc,

--- a/ast_test.go
+++ b/ast_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -257,4 +257,31 @@ func TestGraph_HydrateFieldType_Group(t *testing.T) {
 
 	assert.Nil(t, g.hydrateFieldType(f))
 	assert.True(t, md.Failed())
+}
+
+func TestGraph_Packageless(t *testing.T) {
+	t.Parallel()
+
+	g := buildGraph(t, "packageless")
+
+	tests := []struct {
+		name        string
+		entityIFace interface{}
+	}{
+		{".RootMessage", (*Message)(nil)},
+		{".RootEnum", (*Enum)(nil)},
+		{".RootMessage.field", (*Field)(nil)},
+		{".RootEnum.VALUE", (*EnumValue)(nil)},
+		{".RootMessage.NestedMsg", (*Message)(nil)},
+		{".RootMessage.NestedEnum", (*Enum)(nil)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ent, ok := g.Lookup(tc.name)
+			assert.True(t, ok)
+			assert.NotNil(t, ent)
+			assert.Implements(t, tc.entityIFace, ent)
+		})
+	}
 }

--- a/file.go
+++ b/file.go
@@ -45,7 +45,6 @@ type file struct {
 }
 
 func (f *file) Name() Name                                  { return Name(f.desc.GetName()) }
-func (f *file) FullyQualifiedName() string                  { return "." + f.desc.GetPackage() }
 func (f *file) Syntax() Syntax                              { return Syntax(f.desc.GetSyntax()) }
 func (f *file) Package() Package                            { return f.pkg }
 func (f *file) File() File                                  { return f }
@@ -56,6 +55,13 @@ func (f *file) MapEntries() (me []Message)                  { return nil }
 func (f *file) SourceCodeInfo() SourceCodeInfo              { return f.SyntaxSourceCodeInfo() }
 func (f *file) SyntaxSourceCodeInfo() SourceCodeInfo        { return f.syntaxInfo }
 func (f *file) PackageSourceCodeInfo() SourceCodeInfo       { return f.packageInfo }
+
+func (f *file) FullyQualifiedName() string {
+	if pkg := f.desc.GetPackage(); pkg != "" {
+		return "." + pkg
+	}
+	return ""
+}
 
 func (f *file) Enums() []Enum {
 	return f.enums

--- a/testdata/graph/packageless/packageless.proto
+++ b/testdata/graph/packageless/packageless.proto
@@ -1,0 +1,17 @@
+syntax="proto3";
+
+// no package declaration!
+
+message RootMessage {
+    RootEnum field = 1;
+
+    message NestedMsg {}
+
+    enum NestedEnum {
+        VALUE = 0;
+    }
+}
+
+enum RootEnum {
+    VALUE = 0;
+}


### PR DESCRIPTION
This patch adds support for packageless (or root scoped) entities. Original FQN builder always assumed a package would be specified (admittedly because I didn't know it was legal to _not_ have a package stanza). 

@charlievieth @twoism 

Fixes #42 