### PR TITLE
include extensions in accept()

### DIFF
--- a/extension_test.go
+++ b/extension_test.go
@@ -191,3 +191,21 @@ func TestProtoExtExtractor(t *testing.T) {
 	assert.NotPanics(t, func() { e.HasExtension(nil, nil) })
 	assert.NotPanics(t, func() { e.GetExtension(nil, nil) })
 }
+
+// needed to wrapped since there is a Extension method
+type mExt interface {
+	Extension
+}
+
+type mockExtension struct {
+	mExt
+	err error
+}
+
+func (e *mockExtension) accept(v Visitor) error {
+	_, err := v.VisitExtension(e)
+	if e.err != nil {
+		return e.err
+	}
+	return err
+}

--- a/file.go
+++ b/file.go
@@ -146,6 +146,12 @@ func (f *file) accept(v Visitor) (err error) {
 		}
 	}
 
+	for _, ext := range f.defExts {
+		if err = ext.accept(v); err != nil {
+			return
+		}
+	}
+
 	return
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -194,16 +194,28 @@ func TestFile_Accept(t *testing.T) {
 	assert.Zero(t, v.enum)
 	assert.Zero(t, v.message)
 	assert.Zero(t, v.service)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	f.addEnum(&enum{})
 	f.addMessage(&msg{})
 	f.addService(&service{})
+	f.addDefExtension(&ext{})
 	assert.NoError(t, f.accept(v))
 	assert.Equal(t, 1, v.file)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.message)
 	assert.Equal(t, 1, v.service)
+	assert.Equal(t, 1, v.extension)
+
+	v.Reset()
+	f.addDefExtension(&mockExtension{err: errors.New("fizz")})
+	assert.EqualError(t, f.accept(v), "fizz")
+	assert.Equal(t, 1, v.file)
+	assert.Equal(t, 1, v.enum)
+	assert.Equal(t, 1, v.message)
+	assert.Equal(t, 1, v.service)
+	assert.Equal(t, 2, v.extension)
 
 	v.Reset()
 	f.addService(&mockService{err: errors.New("fizz")})
@@ -212,6 +224,7 @@ func TestFile_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.message)
 	assert.Equal(t, 2, v.service)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	f.addMessage(&mockMessage{err: errors.New("bar")})
@@ -220,6 +233,7 @@ func TestFile_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 2, v.message)
 	assert.Zero(t, v.service)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	f.addEnum(&mockEnum{err: errors.New("baz")})
@@ -228,6 +242,7 @@ func TestFile_Accept(t *testing.T) {
 	assert.Equal(t, 2, v.enum)
 	assert.Zero(t, v.message)
 	assert.Zero(t, v.service)
+	assert.Zero(t, v.extension)
 }
 
 func TestFile_Extension(t *testing.T) {

--- a/message.go
+++ b/message.go
@@ -189,6 +189,12 @@ func (m *msg) accept(v Visitor) (err error) {
 		}
 	}
 
+	for _, ext := range m.defExts {
+		if err = ext.accept(v); err != nil {
+			return
+		}
+	}
+
 	return
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -250,6 +250,7 @@ func TestMsg_Accept(t *testing.T) {
 	m.addEnum(&enum{})
 	m.addField(&field{})
 	m.addOneOf(&oneof{})
+	m.addDefExtension(&ext{})
 
 	assert.NoError(t, m.accept(nil))
 
@@ -259,6 +260,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Zero(t, v.enum)
 	assert.Zero(t, v.field)
 	assert.Zero(t, v.oneof)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	v.v = v
@@ -268,6 +270,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Zero(t, v.enum)
 	assert.Zero(t, v.field)
 	assert.Zero(t, v.oneof)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	assert.NoError(t, m.accept(v))
@@ -275,6 +278,16 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.field)
 	assert.Equal(t, 1, v.oneof)
+	assert.Equal(t, 1, v.extension)
+
+	v.Reset()
+	m.addDefExtension(&mockExtension{err: errors.New("")})
+	assert.Error(t, m.accept(v))
+	assert.Equal(t, 2, v.message)
+	assert.Equal(t, 1, v.enum)
+	assert.Equal(t, 1, v.field)
+	assert.Equal(t, 1, v.oneof)
+	assert.Equal(t, 2, v.extension)
 
 	v.Reset()
 	m.addOneOf(&mockOneOf{err: errors.New("")})
@@ -283,6 +296,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.field)
 	assert.Equal(t, 2, v.oneof)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	m.addField(&mockField{err: errors.New("")})
@@ -291,6 +305,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 2, v.field)
 	assert.Zero(t, v.oneof)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	m.addMessage(&mockMessage{err: errors.New("")})
@@ -299,6 +314,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.enum)
 	assert.Zero(t, v.field)
 	assert.Zero(t, v.oneof)
+	assert.Zero(t, v.extension)
 
 	v.Reset()
 	m.addEnum(&mockEnum{err: errors.New("")})
@@ -307,6 +323,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.message)
 	assert.Zero(t, v.field)
 	assert.Zero(t, v.oneof)
+	assert.Zero(t, v.extension)
 }
 
 func TestMsg_Imports(t *testing.T) {


### PR DESCRIPTION
Previously, extensions were not being visited by `Walk()` because they were not included on File and Message's `accept()`.