### PR TITLE
add reference to entity's dependents to entity

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -328,6 +328,7 @@ func (g *graph) hydrateField(m Message, fd *descriptor.FieldDescriptorProto) Fie
 	f := &field{
 		desc: fd,
 		msg:  m,
+		deps: []Entity{},
 	}
 	f.fqn = fullyQualifiedName(f.msg, f)
 	g.add(f)

--- a/ast.go
+++ b/ast.go
@@ -43,12 +43,12 @@ func (g *graph) Lookup(name string) (Entity, bool) {
 
 // ProcessDescriptors is deprecated; use ProcessCodeGeneratorRequest instead
 func ProcessDescriptors(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST {
-	return ProcessCodeGeneratorRequest(debug, req)
+	return ProcessCodeGeneratorRequest(debug, req, false)
 }
 
 // ProcessCodeGeneratorRequest converts a CodeGeneratorRequest from protoc into a fully
 // connected AST entity graph. An error is returned if the input is malformed.
-func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST {
+func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorRequest, bidirectional bool) AST {
 	g := &graph{
 		d:          debug,
 		targets:    make(map[string]File, len(req.GetFileToGenerate())),
@@ -100,7 +100,7 @@ func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorReq
 // populated.
 func ProcessFileDescriptorSet(debug Debugger, fdset *descriptor.FileDescriptorSet) AST {
 	req := plugin_go.CodeGeneratorRequest{ProtoFile: fdset.File}
-	return ProcessCodeGeneratorRequest(debug, &req)
+	return ProcessCodeGeneratorRequest(debug, &req, false)
 }
 
 func (g *graph) hydratePackage(f *descriptor.FileDescriptorProto) Package {

--- a/ast.go
+++ b/ast.go
@@ -463,15 +463,15 @@ func (g *graph) resolveFQN(e Entity) string {
 	return e.FullyQualifiedName()
 }
 
-func (g *graph) assignDependent(ft FieldType, parent Entity) {
+func assignDependent(ft FieldType, parent Entity) {
 	if ft.IsEnum() {
 		enum := ft.Enum()
-		if g.resolveFQN(enum.Parent()) != g.resolveFQN(parent) {
+		if enum.Parent().FullyQualifiedName() != parent.FullyQualifiedName() {
 			enum.addDependent(parent)
 		}
 	} else if ft.IsEmbed() {
 		msg := ft.Embed()
-		if g.resolveFQN(msg.Parent()) != g.resolveFQN(parent) {
+		if msg.Parent().FullyQualifiedName() != parent.FullyQualifiedName() {
 			msg.addDependent(parent)
 		}
 	}

--- a/ast.go
+++ b/ast.go
@@ -161,8 +161,9 @@ func (g *graph) hydrateFile(pkg Package, f *descriptor.FileDescriptorProto) File
 
 	for _, dep := range f.GetDependency() {
 		// the AST is built in topological order so a file's dependencies are always hydrated first
-		fileDep := g.mustSeen(dep).(File)
-		fl.addFileDep(fileDep)
+		d := g.mustSeen(dep).(File)
+		fl.addFileDependency(d)
+		d.addDependent(fl)
 	}
 
 	if _, fl.buildTarget = g.targets[f.GetName()]; fl.buildTarget {
@@ -206,7 +207,7 @@ func (g *graph) hydrateFile(pkg Package, f *descriptor.FileDescriptorProto) File
 		}
 	}
 
-	fl.fileDeps = make([]File, 0)
+	fl.fileDependencies = make([]File, 0)
 
 	g.hydrateSourceCodeInfo(fl, f)
 

--- a/ast.go
+++ b/ast.go
@@ -88,14 +88,13 @@ func ProcessCodeGeneratorRequestBidirectional(debug Debugger, req *plugin_go.Cod
 			if len(f.Descriptor().GetDependency()) > 0 {
 				// only going through messages because service imports are handled via method hydration.
 				for _, m := range f.AllMessages() {
-					mFile := m.File().Name()
 					for _, field := range m.NonOneOfFields() {
-						assignDependent(field.Type(), m, mFile)
+						assignDependent(field.Type(), m)
 					}
 
 					for _, o := range m.OneOfs() {
 						for _, field := range o.Fields() {
-							assignDependent(field.Type(), o, mFile)
+							assignDependent(field.Type(), o)
 						}
 					}
 				}
@@ -463,15 +462,15 @@ func (g *graph) resolveFQN(e Entity) string {
 	return e.FullyQualifiedName()
 }
 
-func assignDependent(ft FieldType, parent Entity, parentFile Name) {
+func assignDependent(ft FieldType, parent Entity) {
 	if ft.IsEnum() {
 		enum := ft.Enum()
-		if enum.File().Name() != parentFile {
+		if enum.File().Name() != parent.Name() {
 			enum.addDependent(parent)
 		}
 	} else if ft.IsEmbed() {
 		msg := ft.Embed()
-		if msg.File().Name() != parentFile {
+		if msg.File().Name() != parent.Name() {
 			msg.addDependent(parent)
 		}
 	}

--- a/ast.go
+++ b/ast.go
@@ -47,7 +47,9 @@ func ProcessDescriptors(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST
 }
 
 // ProcessCodeGeneratorRequest converts a CodeGeneratorRequest from protoc into a fully
-// connected AST entity graph. An error is returned if the input is malformed.
+// connected AST entity graph. Set bidirectional to True for the AST to be built with
+// a complete list of a given entity's dependents rather than a shallow list. An error
+// is returned if the input is malformed.
 func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorRequest, bidirectional bool) AST {
 	g := &graph{
 		d:          debug,
@@ -107,9 +109,11 @@ func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorReq
 }
 
 // ProcessFileDescriptorSet conversts a FileDescriptorSet from protoc into a
-// fully connected AST entity graph. An error is returned if the input is
-// malformed or missing dependencies. To generate a self-contained
-// FileDescriptorSet, run the following command:
+// fully connected AST entity graph. Set bidirectional to True for the AST to
+// be built with a complete list of a given entity's dependents rather than a
+// shallow list. An error is returned if the input is malformed or missing
+// dependencies. To generate a self-contained FileDescriptorSet, run the
+// following command:
 //
 //   protoc -o path/to/fdset.bin --include_imports $PROTO_FILES
 //

--- a/ast.go
+++ b/ast.go
@@ -75,8 +75,8 @@ func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorReq
 			f.addFileDep(fileDep)
 		}
 
-		// don't need to go through services bc imports are handled during method hydration
-		if bidirectional { // TODO: figure out how to handle file level imports, maybe do something w/ the enumval
+		if bidirectional {
+			// only going through messages because service imports are handled via method hydration.
 			for _, m := range f.AllMessages() {
 				if len(m.Imports()) > 0 {
 					for _, field := range m.NonOneOfFields() {

--- a/ast.go
+++ b/ast.go
@@ -97,7 +97,15 @@ func ProcessCodeGeneratorRequestBidirectional(debug Debugger, req *plugin_go.Cod
 							assignDependent(field.Type(), o)
 						}
 					}
+
+					for _, e := range m.DefinedExtensions() {
+						assignDependent(e.Type(), e)
+					}
 				}
+			}
+
+			for _, e := range f.DefinedExtensions() {
+				assignDependent(e.Type(), e)
 			}
 		}
 	}

--- a/ast_test.go
+++ b/ast_test.go
@@ -337,9 +337,8 @@ func TestGraph_Bidirectional(t *testing.T) {
 
 	fdset := readFileDescSet(t, "testdata/fdset.bin")
 	d := InitMockDebugger()
-	ast := ProcessFileDescriptorSet(d, fdset)
+	ast := ProcessFileDescriptorSetBidirectional(d, fdset)
 	require.False(t, d.Failed(), "failed to build graph from FDSet")
-	ast.MakeBidirectional()
 
 	finish, ok := ast.Lookup(".kitchen.Sink.Material.Finish")
 	require.True(t, ok)

--- a/ast_test.go
+++ b/ast_test.go
@@ -356,3 +356,25 @@ func TestGraph_Bidirectional(t *testing.T) {
 	assert.Contains(t, deps, kitchen)
 	assert.Contains(t, deps, kitchen.File())
 }
+
+func TestGraph_BidirectionalExtensions(t *testing.T) {
+	t.Parallel()
+
+	d := InitMockDebugger()
+	ast := ProcessCodeGeneratorRequestBidirectional(d, readCodeGenReq(t, "extensions"))
+	require.False(t, d.Failed(), "failed to build graph (see previous log statements)")
+
+	enumExtension, ok := ast.Lookup(".extensions.ext.EnumExtension")
+	require.True(t, ok)
+	enumOptions, ok := ast.Lookup(".google.protobuf.EnumOptions")
+	require.True(t, ok)
+	extension, ok := ast.Lookup(".extensions.ext.ext")
+	require.True(t, ok)
+	deps := enumExtension.Dependents()
+
+	require.Len(t, deps, 4)
+	assert.Contains(t, deps, enumExtension.File())
+	assert.Contains(t, deps, enumOptions)
+	assert.Contains(t, deps, enumOptions.File())
+	assert.Contains(t, deps, extension)
+}

--- a/ast_test.go
+++ b/ast_test.go
@@ -47,7 +47,7 @@ func buildGraph(t *testing.T, dir string) AST {
 func TestGraph_FDSet(t *testing.T) {
 	fdset := readFileDescSet(t, "testdata/fdset.bin")
 	d := InitMockDebugger()
-	ast := ProcessFileDescriptorSet(d, fdset)
+	ast := ProcessFileDescriptorSet(d, fdset, false)
 
 	require.False(t, d.Failed(), "failed to build graph from FDSet")
 	msg, found := ast.Lookup(".kitchen.Sink")

--- a/ast_test.go
+++ b/ast_test.go
@@ -39,7 +39,7 @@ func readFileDescSet(t *testing.T, filename string) *descriptor.FileDescriptorSe
 
 func buildGraph(t *testing.T, dir string) AST {
 	d := InitMockDebugger()
-	ast := ProcessCodeGeneratorRequest(d, readCodeGenReq(t, dir))
+	ast := ProcessCodeGeneratorRequest(d, readCodeGenReq(t, dir), false)
 	require.False(t, d.Failed(), "failed to build graph (see previous log statements)")
 	return ast
 }

--- a/ast_test.go
+++ b/ast_test.go
@@ -377,4 +377,9 @@ func TestGraph_BidirectionalExtensions(t *testing.T) {
 	assert.Contains(t, deps, enumOptions)
 	assert.Contains(t, deps, enumOptions.File())
 	assert.Contains(t, deps, extension)
+
+	extDeps := extension.Dependents()
+	require.Len(t, extDeps, 2)
+	assert.Contains(t, extDeps, enumOptions)
+	assert.Contains(t, extDeps, enumOptions.File())
 }

--- a/ast_test.go
+++ b/ast_test.go
@@ -1,6 +1,7 @@
 package pgs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -371,6 +372,18 @@ func TestGraph_BidirectionalExtensions(t *testing.T) {
 	extension, ok := ast.Lookup(".extensions.ext.ext")
 	require.True(t, ok)
 	deps := enumExtension.Dependents()
+	for _, d := range deps {
+		if f, ok := d.(File); ok {
+			fmt.Println(f.Name().String())
+		} else {
+			fmt.Println(d.FullyQualifiedName())
+		}
+	}
+
+	fmt.Println("00000")
+	for _, d := range enumOptions.File().Dependents() {
+		fmt.Println(d.Name().String())
+	}
 
 	require.Len(t, deps, 4)
 	assert.Contains(t, deps, enumExtension.File())

--- a/entity.go
+++ b/entity.go
@@ -27,6 +27,9 @@ type Entity interface {
 	// Imports includes all external files required by this entity.
 	Imports() []File
 
+	// Dependents includes all entities that require this entity.
+	Dependents() []Entity
+
 	// File returns the File containing this entity.
 	File() File
 

--- a/entity.go
+++ b/entity.go
@@ -27,7 +27,11 @@ type Entity interface {
 	// Imports includes all external files required by this entity.
 	Imports() []File
 
-	// Dependents includes all entities that require this entity.
+	// Dependents includes all entities that require this entity. Note that the
+	// slice will only contain a complete set of dependents (transitive and direct)
+	// if the AST was built via ProcessCodeGeneratorRequestBidirectional or
+	// ProcessFileDescriptorSetBidirectional. Otherwise this call will only include
+	// direct dependents.
 	Dependents() []Entity
 
 	// File returns the File containing this entity.

--- a/enum.go
+++ b/enum.go
@@ -48,7 +48,7 @@ func (e *enum) Imports() []File                             { return nil }
 func (e *enum) Values() []EnumValue                         { return e.vals }
 
 func (e *enum) Dependents() []Entity {
-	if len(e.depCache) == 0 {
+	if e.depCache == nil {
 		set := make(map[string]Entity)
 
 		set[e.resolveFQN(e.parent)] = e.parent

--- a/enum.go
+++ b/enum.go
@@ -43,6 +43,7 @@ func (e *enum) Descriptor() *descriptor.EnumDescriptorProto { return e.desc }
 func (e *enum) Parent() ParentEntity                        { return e.parent }
 func (e *enum) Imports() []File                             { return nil }
 func (e *enum) Values() []EnumValue                         { return e.vals }
+func (e *enum) Dependents() []Entity                        { return append(e.parent.Dependents(), e.parent) }
 
 func (e *enum) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
 	return extension(e.desc.GetOptions(), desc, &ext)

--- a/enum.go
+++ b/enum.go
@@ -49,11 +49,9 @@ func (e *enum) Values() []EnumValue                         { return e.vals }
 func (e *enum) Dependents() []Entity {
 	dependents := append(e.parent.Dependents(), e.parent)
 
-	if len(e.deps) > 0 { // e.deps is only populated if the AST is bidirectional
-		for _, d := range e.deps {
-			dependents = append(dependents, d.Dependents()...)
-			dependents = append(dependents, d)
-		}
+	for _, d := range e.deps {
+		dependents = append(dependents, d.Dependents()...)
+		dependents = append(dependents, d)
 	}
 
 	return dependents

--- a/enum_test.go
+++ b/enum_test.go
@@ -105,6 +105,35 @@ func TestEnum_Extension(t *testing.T) {
 	assert.NotPanics(t, func() { e.Extension(nil, nil) })
 }
 
+func TestEnum_Dependents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enum in file", func(t *testing.T) {
+		t.Parallel()
+
+		e := &enum{}
+		f := dummyFile()
+		f.addEnum(e)
+		deps := e.Dependents()
+
+		assert.Len(t, deps, 1)
+		assert.Equal(t, f, deps[0])
+	})
+
+	t.Run("enum in message", func(t *testing.T) {
+		t.Parallel()
+
+		e := &enum{}
+		m := dummyMsg()
+		m.addEnum(e)
+		deps := e.Dependents()
+
+		assert.Len(t, deps, 2)
+		assert.Contains(t, deps, m)
+		assert.Contains(t, deps, m.File())
+	})
+}
+
 func TestEnum_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -132,6 +132,22 @@ func TestEnum_Dependents(t *testing.T) {
 		assert.Contains(t, deps, m)
 		assert.Contains(t, deps, m.File())
 	})
+
+	t.Run("external dependents", func(t *testing.T) {
+		t.Parallel()
+
+		e := &enum{}
+		f := dummyFile()
+		f.addEnum(e)
+		m := dummyMsg()
+		e.addDependent(m)
+		deps := e.Dependents()
+
+		assert.Len(t, deps, 3)
+		assert.Contains(t, deps, f)
+		assert.Contains(t, deps, m)
+		assert.Contains(t, deps, m.File())
+	})
 }
 
 func TestEnum_Accept(t *testing.T) {

--- a/enum_test.go
+++ b/enum_test.go
@@ -136,8 +136,16 @@ func TestEnum_Dependents(t *testing.T) {
 	t.Run("external dependents", func(t *testing.T) {
 		t.Parallel()
 
+		pkg := dummyPkg()
+		f := &file{
+			pkg: pkg,
+			desc: &descriptor.FileDescriptorProto{
+				Package: proto.String(pkg.ProtoName().String()),
+				Syntax:  proto.String(string(Proto3)),
+				Name:    proto.String("test_file.proto"),
+			},
+		}
 		e := &enum{}
-		f := dummyFile()
 		f.addEnum(e)
 		m := dummyMsg()
 		e.addDependent(m)

--- a/enum_value.go
+++ b/enum_value.go
@@ -40,6 +40,7 @@ func (ev *enumVal) Descriptor() *descriptor.EnumValueDescriptorProto { return ev
 func (ev *enumVal) Enum() Enum                                       { return ev.enum }
 func (ev *enumVal) Value() int32                                     { return ev.desc.GetNumber() }
 func (ev *enumVal) Imports() []File                                  { return nil }
+func (ev *enumVal) Dependents() []Entity                             { return append(ev.enum.Dependents(), ev.enum) }
 
 func (ev *enumVal) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
 	return extension(ev.desc.GetOptions(), desc, &ext)

--- a/enum_value.go
+++ b/enum_value.go
@@ -22,9 +22,10 @@ type EnumValue interface {
 }
 
 type enumVal struct {
-	desc *descriptor.EnumValueDescriptorProto
-	enum Enum
-	fqn  string
+	desc            *descriptor.EnumValueDescriptorProto
+	enum            Enum
+	fqn             string
+	dependentsCache []Entity
 
 	info SourceCodeInfo
 }
@@ -40,7 +41,13 @@ func (ev *enumVal) Descriptor() *descriptor.EnumValueDescriptorProto { return ev
 func (ev *enumVal) Enum() Enum                                       { return ev.enum }
 func (ev *enumVal) Value() int32                                     { return ev.desc.GetNumber() }
 func (ev *enumVal) Imports() []File                                  { return nil }
-func (ev *enumVal) Dependents() []Entity                             { return append(ev.enum.Dependents(), ev.enum) }
+
+func (ev *enumVal) Dependents() []Entity {
+	if len(ev.dependentsCache) == 0 {
+		ev.dependentsCache = append(ev.enum.Dependents(), ev.enum)
+	}
+	return ev.dependentsCache
+}
 
 func (ev *enumVal) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
 	return extension(ev.desc.GetOptions(), desc, &ext)

--- a/enum_value.go
+++ b/enum_value.go
@@ -43,8 +43,9 @@ func (ev *enumVal) Value() int32                                     { return ev
 func (ev *enumVal) Imports() []File                                  { return nil }
 
 func (ev *enumVal) Dependents() []Entity {
-	if len(ev.dependentsCache) == 0 {
-		ev.dependentsCache = append(ev.enum.Dependents(), ev.enum)
+	if ev.dependentsCache == nil {
+		ev.dependentsCache = []Entity{ev.enum}
+		ev.dependentsCache = append(ev.dependentsCache, ev.enum.Dependents()...)
 	}
 	return ev.dependentsCache
 }

--- a/enum_value_test.go
+++ b/enum_value_test.go
@@ -90,6 +90,19 @@ func TestEnumVal_Extension(t *testing.T) {
 	assert.NotPanics(t, func() { ev.Extension(nil, nil) })
 }
 
+func TestEnumVal_Dependents(t *testing.T) {
+	t.Parallel()
+
+	ev := &enumVal{}
+	e := dummyEnum()
+	e.addValue(ev)
+	deps := ev.Dependents()
+
+	assert.Len(t, deps, 2)
+	assert.Contains(t, deps, e)
+	assert.Contains(t, deps, e.File())
+}
+
 func TestEnumVal_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/extension.go
+++ b/extension.go
@@ -25,9 +25,10 @@ type Extension interface {
 type ext struct {
 	field
 
-	parent   ParentEntity
-	extendee Message
-	fqn      string
+	parent          ParentEntity
+	extendee        Message
+	fqn             string
+	dependentsCache []Entity
 }
 
 func (e *ext) FullyQualifiedName() string { return e.fqn }
@@ -43,7 +44,13 @@ func (e *ext) OneOf() OneOf               { return nil }
 func (e *ext) setMessage(m Message)       {} // noop
 func (e *ext) setOneOf(o OneOf)           {} // noop
 func (e *ext) setExtendee(m Message)      { e.extendee = m }
-func (e *ext) Dependents() []Entity       { return []Entity{e.extendee} }
+
+func (e *ext) Dependents() []Entity {
+	if len(e.dependentsCache) == 0 {
+		e.dependentsCache = append(e.extendee.Dependents(), e.extendee)
+	}
+	return e.dependentsCache
+}
 
 func (e *ext) accept(v Visitor) (err error) {
 	if v == nil {

--- a/extension.go
+++ b/extension.go
@@ -46,8 +46,9 @@ func (e *ext) setOneOf(o OneOf)           {} // noop
 func (e *ext) setExtendee(m Message)      { e.extendee = m }
 
 func (e *ext) Dependents() []Entity {
-	if len(e.dependentsCache) == 0 {
-		e.dependentsCache = append(e.extendee.Dependents(), e.extendee)
+	if e.dependentsCache == nil {
+		e.dependentsCache = []Entity{e.extendee}
+		e.dependentsCache = append(e.dependentsCache, e.extendee.Dependents()...)
 	}
 	return e.dependentsCache
 }

--- a/extension.go
+++ b/extension.go
@@ -25,10 +25,9 @@ type Extension interface {
 type ext struct {
 	field
 
-	parent          ParentEntity
-	extendee        Message
-	fqn             string
-	dependentsCache []Entity
+	parent   ParentEntity
+	extendee Message
+	fqn      string
 }
 
 func (e *ext) FullyQualifiedName() string { return e.fqn }
@@ -44,13 +43,7 @@ func (e *ext) OneOf() OneOf               { return nil }
 func (e *ext) setMessage(m Message)       {} // noop
 func (e *ext) setOneOf(o OneOf)           {} // noop
 func (e *ext) setExtendee(m Message)      { e.extendee = m }
-
-func (e *ext) Dependents() []Entity {
-	if len(e.dependentsCache) == 0 {
-		e.dependentsCache = append(e.parent.Dependents(), e.parent)
-	}
-	return e.dependentsCache
-}
+func (e *ext) Dependents() []Entity       { return []Entity{e.extendee} }
 
 func (e *ext) accept(v Visitor) (err error) {
 	if v == nil {

--- a/extension.go
+++ b/extension.go
@@ -36,7 +36,7 @@ func (e *ext) Package() Package           { return e.parent.Package() }
 func (e *ext) File() File                 { return e.parent.File() }
 func (e *ext) BuildTarget() bool          { return e.parent.BuildTarget() }
 func (e *ext) DefinedIn() ParentEntity    { return e.parent }
-func (e *ext) Dependents() []Entity       { return nil }
+func (e *ext) Dependents() []Entity       { return append(e.parent.Dependents(), e.parent) }
 func (e *ext) Extendee() Message          { return e.extendee }
 func (e *ext) Message() Message           { return nil }
 func (e *ext) InOneOf() bool              { return false }

--- a/extension.go
+++ b/extension.go
@@ -25,9 +25,10 @@ type Extension interface {
 type ext struct {
 	field
 
-	parent   ParentEntity
-	extendee Message
-	fqn      string
+	parent          ParentEntity
+	extendee        Message
+	fqn             string
+	dependentsCache []Entity
 }
 
 func (e *ext) FullyQualifiedName() string { return e.fqn }
@@ -36,7 +37,6 @@ func (e *ext) Package() Package           { return e.parent.Package() }
 func (e *ext) File() File                 { return e.parent.File() }
 func (e *ext) BuildTarget() bool          { return e.parent.BuildTarget() }
 func (e *ext) DefinedIn() ParentEntity    { return e.parent }
-func (e *ext) Dependents() []Entity       { return append(e.parent.Dependents(), e.parent) }
 func (e *ext) Extendee() Message          { return e.extendee }
 func (e *ext) Message() Message           { return nil }
 func (e *ext) InOneOf() bool              { return false }
@@ -44,6 +44,13 @@ func (e *ext) OneOf() OneOf               { return nil }
 func (e *ext) setMessage(m Message)       {} // noop
 func (e *ext) setOneOf(o OneOf)           {} // noop
 func (e *ext) setExtendee(m Message)      { e.extendee = m }
+
+func (e *ext) Dependents() []Entity {
+	if len(e.dependentsCache) == 0 {
+		e.dependentsCache = append(e.parent.Dependents(), e.parent)
+	}
+	return e.dependentsCache
+}
 
 func (e *ext) accept(v Visitor) (err error) {
 	if v == nil {

--- a/extension.go
+++ b/extension.go
@@ -36,6 +36,7 @@ func (e *ext) Package() Package           { return e.parent.Package() }
 func (e *ext) File() File                 { return e.parent.File() }
 func (e *ext) BuildTarget() bool          { return e.parent.BuildTarget() }
 func (e *ext) DefinedIn() ParentEntity    { return e.parent }
+func (e *ext) Dependents() []Entity       { return nil }
 func (e *ext) Extendee() Message          { return e.extendee }
 func (e *ext) Message() Message           { return nil }
 func (e *ext) InOneOf() bool              { return false }

--- a/extension_test.go
+++ b/extension_test.go
@@ -93,8 +93,9 @@ func TestExt_Dependents(t *testing.T) {
 	e := &ext{extendee: msg}
 	deps := e.Dependents()
 
-	assert.Len(t, deps, 1)
+	assert.Len(t, deps, 2)
 	assert.Contains(t, deps, msg)
+	assert.Contains(t, deps, msg.File())
 }
 
 func TestExt_Accept(t *testing.T) {

--- a/extension_test.go
+++ b/extension_test.go
@@ -90,12 +90,11 @@ func TestExt_Dependents(t *testing.T) {
 	t.Parallel()
 
 	msg := dummyMsg()
-	e := &ext{parent: msg}
+	e := &ext{extendee: msg}
 	deps := e.Dependents()
 
-	assert.Len(t, deps, 2)
+	assert.Len(t, deps, 1)
 	assert.Contains(t, deps, msg)
-	assert.Contains(t, deps, msg.File())
 }
 
 func TestExt_Accept(t *testing.T) {

--- a/extension_test.go
+++ b/extension_test.go
@@ -86,6 +86,18 @@ func TestExt_OneOf(t *testing.T) {
 	assert.Nil(t, e.OneOf())
 }
 
+func TestExt_Dependents(t *testing.T) {
+	t.Parallel()
+
+	msg := dummyMsg()
+	e := &ext{parent: msg}
+	deps := e.Dependents()
+
+	assert.Len(t, deps, 2)
+	assert.Contains(t, deps, msg)
+	assert.Contains(t, deps, msg.File())
+}
+
 func TestExt_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/field.go
+++ b/field.go
@@ -63,11 +63,13 @@ func (f *field) setMessage(m Message)                         { f.msg = m }
 func (f *field) setOneOf(o OneOf)                             { f.oneof = o }
 
 func (f *field) Dependents() []Entity {
-	if len(f.dependentsCache) == 0 {
+	if f.dependentsCache == nil {
 		if f.InOneOf() {
-			f.dependentsCache = append(f.oneof.Dependents(), f.oneof)
+			f.dependentsCache = []Entity{f.oneof}
+			f.dependentsCache = append(f.dependentsCache, f.oneof.Dependents()...)
 		} else {
-			f.dependentsCache = append(f.msg.Dependents(), f.msg)
+			f.dependentsCache = []Entity{f.msg}
+			f.dependentsCache = append(f.dependentsCache, f.msg.Dependents()...)
 		}
 	}
 	return f.dependentsCache

--- a/field.go
+++ b/field.go
@@ -36,11 +36,12 @@ type Field interface {
 }
 
 type field struct {
-	desc  *descriptor.FieldDescriptorProto
-	fqn   string
-	msg   Message
-	oneof OneOf
-	typ   FieldType
+	desc            *descriptor.FieldDescriptorProto
+	fqn             string
+	msg             Message
+	oneof           OneOf
+	typ             FieldType
+	dependentsCache []Entity
 
 	info SourceCodeInfo
 }
@@ -62,10 +63,14 @@ func (f *field) setMessage(m Message)                         { f.msg = m }
 func (f *field) setOneOf(o OneOf)                             { f.oneof = o }
 
 func (f *field) Dependents() []Entity {
-	if f.InOneOf() {
-		return append(f.oneof.Dependents(), f.oneof)
+	if len(f.dependentsCache) == 0 {
+		if f.InOneOf() {
+			f.dependentsCache = append(f.oneof.Dependents(), f.oneof)
+		} else {
+			f.dependentsCache = append(f.msg.Dependents(), f.msg)
+		}
 	}
-	return append(f.msg.Dependents(), f.msg)
+	return f.dependentsCache
 }
 
 func (f *field) Required() bool {

--- a/field.go
+++ b/field.go
@@ -33,7 +33,6 @@ type Field interface {
 	setMessage(m Message)
 	setOneOf(o OneOf)
 	addType(t FieldType)
-	addDependent(ent Entity)
 }
 
 type field struct {
@@ -42,7 +41,6 @@ type field struct {
 	msg   Message
 	oneof OneOf
 	typ   FieldType
-	deps  []Entity
 
 	info SourceCodeInfo
 }
@@ -64,22 +62,10 @@ func (f *field) setMessage(m Message)                         { f.msg = m }
 func (f *field) setOneOf(o OneOf)                             { f.oneof = o }
 
 func (f *field) Dependents() []Entity {
-	var dependents []Entity
-
 	if f.InOneOf() {
-		dependents = append(f.oneof.Dependents(), f.oneof)
-	} else {
-		dependents = append(f.msg.Dependents(), f.msg)
+		return append(f.oneof.Dependents(), f.oneof)
 	}
-
-	if len(f.deps) > 0 { // f.deps is only populated if the AST is bidirectional
-		for _, d := range f.deps {
-			dependents = append(dependents, d.Dependents()...)
-			dependents = append(dependents, d)
-		}
-	}
-
-	return dependents
+	return append(f.msg.Dependents(), f.msg)
 }
 
 func (f *field) Required() bool {
@@ -113,9 +99,5 @@ func (f *field) childAtPath(path []int32) Entity {
 }
 
 func (f *field) addSourceCodeInfo(info SourceCodeInfo) { f.info = info }
-
-func (f *field) addDependent(ent Entity) {
-	f.deps = append(f.deps, ent)
-}
 
 var _ Field = (*field)(nil)

--- a/field.go
+++ b/field.go
@@ -61,6 +61,13 @@ func (f *field) Type() FieldType                              { return f.typ }
 func (f *field) setMessage(m Message)                         { f.msg = m }
 func (f *field) setOneOf(o OneOf)                             { f.oneof = o }
 
+func (f *field) Dependents() []Entity {
+	if f.InOneOf() {
+		return append(f.oneof.Dependents(), f.oneof)
+	}
+	return append(f.msg.Dependents(), f.msg)
+}
+
 func (f *field) Required() bool {
 	return f.Syntax().SupportsRequiredPrefix() &&
 		f.desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED

--- a/field_test.go
+++ b/field_test.go
@@ -115,6 +115,46 @@ func TestField_Extension(t *testing.T) {
 	assert.NotPanics(t, func() { f.Extension(nil, nil) })
 }
 
+func TestField_Dependents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("field in a one of", func(t *testing.T) {
+		t.Parallel()
+
+		f := &field{}
+		o := dummyOneof()
+		o.addField(f)
+		deps := f.Dependents()
+
+		assert.Len(t, deps, 3)
+		assert.Contains(t, deps, o)
+		assert.Contains(t, deps, o.Message())
+		assert.Contains(t, deps, o.File())
+	})
+
+	t.Run("field in a message", func(t *testing.T) {
+		t.Parallel()
+
+		f := &field{}
+		m := dummyMsg()
+		m.addField(f)
+		deps := f.Dependents()
+
+		assert.Len(t, deps, 2)
+		assert.Contains(t, deps, m)
+		assert.Contains(t, deps, m.File())
+	})
+
+	t.Run("external dependents", func(t *testing.T) {
+		t.Parallel()
+
+		//f := &field{}
+		//m := dummyMsg()
+		//m.addField(f)
+		//f.addDependent() // TODO
+	})
+}
+
 func TestField_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/field_test.go
+++ b/field_test.go
@@ -144,23 +144,6 @@ func TestField_Dependents(t *testing.T) {
 		assert.Contains(t, deps, m)
 		assert.Contains(t, deps, m.File())
 	})
-
-	t.Run("external dependents", func(t *testing.T) {
-		t.Parallel()
-
-		f := &field{}
-		m := dummyMsg()
-		m.addField(f)
-		m2 := dummyMsg()
-		f.addDependent(m2)
-		deps := f.Dependents()
-
-		assert.Len(t, deps, 4)
-		assert.Contains(t, deps, m)
-		assert.Contains(t, deps, m.File())
-		assert.Contains(t, deps, m2)
-		assert.Contains(t, deps, m2.File())
-	})
 }
 
 func TestField_Accept(t *testing.T) {

--- a/field_test.go
+++ b/field_test.go
@@ -148,10 +148,18 @@ func TestField_Dependents(t *testing.T) {
 	t.Run("external dependents", func(t *testing.T) {
 		t.Parallel()
 
-		//f := &field{}
-		//m := dummyMsg()
-		//m.addField(f)
-		//f.addDependent() // TODO
+		f := &field{}
+		m := dummyMsg()
+		m.addField(f)
+		m2 := dummyMsg()
+		f.addDependent(m2)
+		deps := f.Dependents()
+
+		assert.Len(t, deps, 4)
+		assert.Contains(t, deps, m)
+		assert.Contains(t, deps, m.File())
+		assert.Contains(t, deps, m2)
+		assert.Contains(t, deps, m2.File())
 	})
 }
 

--- a/file.go
+++ b/file.go
@@ -61,6 +61,7 @@ func (f *file) MapEntries() (me []Message)                  { return nil }
 func (f *file) SourceCodeInfo() SourceCodeInfo              { return f.SyntaxSourceCodeInfo() }
 func (f *file) SyntaxSourceCodeInfo() SourceCodeInfo        { return f.syntaxInfo }
 func (f *file) PackageSourceCodeInfo() SourceCodeInfo       { return f.packageInfo }
+func (f *file) Dependents() []Entity                        { return nil }
 
 func (f *file) Enums() []Enum {
 	return f.enums

--- a/file_test.go
+++ b/file_test.go
@@ -164,7 +164,7 @@ func TestFile_Imports(t *testing.T) {
 
 	f.addMessage(m)
 	f.addService(svc)
-	f.addFileDep(flDep)
+	f.addFileDependency(flDep)
 	assert.Len(t, f.Imports(), 2)
 
 	nf := &file{desc: &descriptor.FileDescriptorProto{
@@ -178,7 +178,12 @@ func TestFile_Dependents(t *testing.T) {
 	t.Parallel()
 
 	f := &file{}
-	assert.Empty(t, f.Dependents())
+	fl := dummyFile()
+	f.addDependent(fl)
+	deps := f.Dependents()
+
+	assert.Len(t, deps, 1)
+	assert.Contains(t, deps, fl)
 }
 
 func TestFile_Accept(t *testing.T) {

--- a/file_test.go
+++ b/file_test.go
@@ -174,6 +174,13 @@ func TestFile_Imports(t *testing.T) {
 	assert.Len(t, f.Imports(), 3)
 }
 
+func TestFile_Dependents(t *testing.T) {
+	t.Parallel()
+
+	f := &file{}
+	assert.Empty(t, f.Dependents())
+}
+
 func TestFile_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/lang/go/helpers_test.go
+++ b/lang/go/helpers_test.go
@@ -28,7 +28,7 @@ func readCodeGenReq(t *testing.T, dir ...string) *plugin_go.CodeGeneratorRequest
 
 func buildGraph(t *testing.T, dir ...string) pgs.AST {
 	d := pgs.InitMockDebugger()
-	ast := pgs.ProcessCodeGeneratorRequest(d, readCodeGenReq(t, dir...), false)
+	ast := pgs.ProcessCodeGeneratorRequest(d, readCodeGenReq(t, dir...))
 	require.False(t, d.Failed(), "failed to build graph (see previous log statements)")
 	return ast
 }

--- a/lang/go/helpers_test.go
+++ b/lang/go/helpers_test.go
@@ -28,7 +28,7 @@ func readCodeGenReq(t *testing.T, dir ...string) *plugin_go.CodeGeneratorRequest
 
 func buildGraph(t *testing.T, dir ...string) pgs.AST {
 	d := pgs.InitMockDebugger()
-	ast := pgs.ProcessCodeGeneratorRequest(d, readCodeGenReq(t, dir...))
+	ast := pgs.ProcessCodeGeneratorRequest(d, readCodeGenReq(t, dir...), false)
 	require.False(t, d.Failed(), "failed to build graph (see previous log statements)")
 	return ast
 }

--- a/message.go
+++ b/message.go
@@ -91,11 +91,9 @@ func (m *msg) MapEntries() []Message                   { return m.maps }
 
 func (m *msg) Dependents() []Entity {
 	dependents := append(m.parent.Dependents(), m.parent)
-	if len(m.deps) > 0 { // m.deps is only populated if the AST is bidirectional
-		for _, d := range m.deps {
-			dependents = append(dependents, d.Dependents()...)
-			dependents = append(dependents, d)
-		}
+	for _, d := range m.deps {
+		dependents = append(dependents, d.Dependents()...)
+		dependents = append(dependents, d)
 	}
 	return dependents
 }

--- a/message.go
+++ b/message.go
@@ -91,7 +91,7 @@ func (m *msg) OneOfs() []OneOf                         { return m.oneofs }
 func (m *msg) MapEntries() []Message                   { return m.maps }
 
 func (m *msg) Dependents() []Entity {
-	if len(m.dependentsCache) == 0 {
+	if m.dependentsCache == nil {
 		set := make(map[string]Entity)
 
 		set[m.resolveFQN(m.parent)] = m.parent

--- a/message.go
+++ b/message.go
@@ -86,6 +86,7 @@ func (m *msg) Messages() []Message                     { return m.msgs }
 func (m *msg) Fields() []Field                         { return m.fields }
 func (m *msg) OneOfs() []OneOf                         { return m.oneofs }
 func (m *msg) MapEntries() []Message                   { return m.maps }
+func (m *msg) Dependents() []Entity                    { return append(m.parent.Dependents(), m.parent) }
 
 func (m *msg) WellKnownType() WellKnownType {
 	if m.Package().ProtoName() == WellKnownTypePackage {

--- a/message_test.go
+++ b/message_test.go
@@ -257,8 +257,17 @@ func TestMsg_Dependents(t *testing.T) {
 	t.Run("external deps", func(t *testing.T) {
 		t.Parallel()
 
+		pkg := dummyPkg()
+		f := &file{
+			pkg: pkg,
+			desc: &descriptor.FileDescriptorProto{
+				Package: proto.String(pkg.ProtoName().String()),
+				Syntax:  proto.String(string(Proto3)),
+				Name:    proto.String("test_file.proto"),
+			},
+		}
+
 		m := &msg{}
-		f := dummyFile()
 		f.addMessage(m)
 		m2 := dummyMsg()
 		m.addDependent(m2)

--- a/message_test.go
+++ b/message_test.go
@@ -239,6 +239,38 @@ func TestMsg_DefinedExtensions(t *testing.T) {
 	assert.Len(t, m.DefinedExtensions(), 1)
 }
 
+func TestMsg_Dependents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no external deps", func(t *testing.T) {
+		t.Parallel()
+
+		m := &msg{}
+		f := dummyFile()
+		f.addMessage(m)
+		deps := m.Dependents()
+
+		assert.Len(t, deps, 1)
+		assert.Contains(t, deps, f)
+	})
+
+	t.Run("external deps", func(t *testing.T) {
+		t.Parallel()
+
+		m := &msg{}
+		f := dummyFile()
+		f.addMessage(m)
+		m2 := dummyMsg()
+		m.addDependent(m2)
+		deps := m.Dependents()
+
+		assert.Len(t, deps, 3)
+		assert.Contains(t, deps, f)
+		assert.Contains(t, deps, m2)
+		assert.Contains(t, deps, m2.File())
+	})
+}
+
 func TestMsg_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/method.go
+++ b/method.go
@@ -54,6 +54,7 @@ func (m *method) Output() Message                               { return m.out }
 func (m *method) ClientStreaming() bool                         { return m.desc.GetClientStreaming() }
 func (m *method) ServerStreaming() bool                         { return m.desc.GetServerStreaming() }
 func (m *method) BiDirStreaming() bool                          { return m.ClientStreaming() && m.ServerStreaming() }
+func (m *method) Dependents() []Entity                          { return append(m.service.Dependents(), m.service) }
 
 func (m *method) Imports() (i []File) {
 	mine := m.File().Name()

--- a/method.go
+++ b/method.go
@@ -57,8 +57,9 @@ func (m *method) ServerStreaming() bool                         { return m.desc.
 func (m *method) BiDirStreaming() bool                          { return m.ClientStreaming() && m.ServerStreaming() }
 
 func (m *method) Dependents() []Entity {
-	if len(m.dependentsCache) == 0 {
-		m.dependentsCache = append(m.service.Dependents(), m.service)
+	if m.dependentsCache == nil {
+		m.dependentsCache = []Entity{m.service}
+		m.dependentsCache = append(m.dependentsCache, m.service.Dependents()...)
 	}
 	return m.dependentsCache
 }

--- a/method.go
+++ b/method.go
@@ -31,9 +31,10 @@ type Method interface {
 }
 
 type method struct {
-	desc    *descriptor.MethodDescriptorProto
-	fqn     string
-	service Service
+	desc            *descriptor.MethodDescriptorProto
+	fqn             string
+	service         Service
+	dependentsCache []Entity
 
 	in, out Message
 
@@ -54,7 +55,13 @@ func (m *method) Output() Message                               { return m.out }
 func (m *method) ClientStreaming() bool                         { return m.desc.GetClientStreaming() }
 func (m *method) ServerStreaming() bool                         { return m.desc.GetServerStreaming() }
 func (m *method) BiDirStreaming() bool                          { return m.ClientStreaming() && m.ServerStreaming() }
-func (m *method) Dependents() []Entity                          { return append(m.service.Dependents(), m.service) }
+
+func (m *method) Dependents() []Entity {
+	if len(m.dependentsCache) == 0 {
+		m.dependentsCache = append(m.service.Dependents(), m.service)
+	}
+	return m.dependentsCache
+}
 
 func (m *method) Imports() (i []File) {
 	mine := m.File().Name()

--- a/method_test.go
+++ b/method_test.go
@@ -152,6 +152,22 @@ func TestMethod_Extension(t *testing.T) {
 	assert.NotPanics(t, func() { m.Extension(nil, nil) })
 }
 
+func TestMethod_Dependents(t *testing.T) {
+	t.Parallel()
+
+	s := dummyService()
+	m := &method{
+		in:  dummyMsg(),
+		out: dummyMsg(),
+	}
+	s.addMethod(m)
+	deps := m.Dependents()
+
+	assert.Len(t, deps, 2)
+	assert.Contains(t, deps, s)
+	assert.Contains(t, deps, s.File())
+}
+
 func TestMethod_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/oneof.go
+++ b/oneof.go
@@ -24,10 +24,11 @@ type OneOf interface {
 }
 
 type oneof struct {
-	desc *descriptor.OneofDescriptorProto
-	msg  Message
-	flds []Field
-	fqn  string
+	desc            *descriptor.OneofDescriptorProto
+	msg             Message
+	flds            []Field
+	fqn             string
+	dependentsCache []Entity
 
 	info SourceCodeInfo
 }
@@ -50,8 +51,14 @@ func (o *oneof) BuildTarget() bool                            { return o.msg.Bui
 func (o *oneof) SourceCodeInfo() SourceCodeInfo               { return o.info }
 func (o *oneof) Descriptor() *descriptor.OneofDescriptorProto { return o.desc }
 func (o *oneof) Message() Message                             { return o.msg }
-func (o *oneof) Dependents() []Entity                         { return append(o.msg.Dependents(), o.msg) }
 func (o *oneof) setMessage(m Message)                         { o.msg = m }
+
+func (o *oneof) Dependents() []Entity {
+	if len(o.dependentsCache) == 0 {
+		o.dependentsCache = append(o.msg.Dependents(), o.msg)
+	}
+	return o.dependentsCache
+}
 
 func (o *oneof) Imports() (i []File) {
 	// Mapping for avoiding duplicate entries

--- a/oneof.go
+++ b/oneof.go
@@ -54,8 +54,9 @@ func (o *oneof) Message() Message                             { return o.msg }
 func (o *oneof) setMessage(m Message)                         { o.msg = m }
 
 func (o *oneof) Dependents() []Entity {
-	if len(o.dependentsCache) == 0 {
-		o.dependentsCache = append(o.msg.Dependents(), o.msg)
+	if o.dependentsCache == nil {
+		o.dependentsCache = []Entity{o.msg}
+		o.dependentsCache = append(o.dependentsCache, o.msg.Dependents()...)
 	}
 	return o.dependentsCache
 }

--- a/oneof.go
+++ b/oneof.go
@@ -50,6 +50,7 @@ func (o *oneof) BuildTarget() bool                            { return o.msg.Bui
 func (o *oneof) SourceCodeInfo() SourceCodeInfo               { return o.info }
 func (o *oneof) Descriptor() *descriptor.OneofDescriptorProto { return o.desc }
 func (o *oneof) Message() Message                             { return o.msg }
+func (o *oneof) Dependents() []Entity                         { return append(o.msg.Dependents(), o.msg) }
 func (o *oneof) setMessage(m Message)                         { o.msg = m }
 
 func (o *oneof) Imports() (i []File) {

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -119,6 +119,19 @@ func TestOneof_Fields(t *testing.T) {
 	assert.Len(t, o.Fields(), 1)
 }
 
+func TestOneof_Dependents(t *testing.T) {
+	t.Parallel()
+
+	m := dummyMsg()
+	o := &oneof{}
+	m.addOneOf(o)
+	deps := o.Dependents()
+
+	assert.Len(t, deps, 2)
+	assert.Contains(t, deps, m)
+	assert.Contains(t, deps, m.File())
+}
+
 func TestOneof_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/service.go
+++ b/service.go
@@ -39,8 +39,9 @@ func (s *service) SourceCodeInfo() SourceCodeInfo                 { return s.inf
 func (s *service) Descriptor() *descriptor.ServiceDescriptorProto { return s.desc }
 
 func (s *service) Dependents() []Entity {
-	if len(s.dependentsCache) == 0 {
-		s.dependentsCache = append(s.file.Dependents(), s.file)
+	if s.dependentsCache == nil {
+		s.dependentsCache = []Entity{s.file}
+		s.dependentsCache = append(s.dependentsCache, s.file.Dependents()...)
 	}
 	return s.dependentsCache
 }

--- a/service.go
+++ b/service.go
@@ -36,6 +36,7 @@ func (s *service) File() File                                     { return s.fil
 func (s *service) BuildTarget() bool                              { return s.file.BuildTarget() }
 func (s *service) SourceCodeInfo() SourceCodeInfo                 { return s.info }
 func (s *service) Descriptor() *descriptor.ServiceDescriptorProto { return s.desc }
+func (s *service) Dependents() []Entity                           { return append(s.file.Dependents(), s.file) }
 
 func (s *service) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
 	return extension(s.desc.GetOptions(), desc, &ext)

--- a/service.go
+++ b/service.go
@@ -20,10 +20,11 @@ type Service interface {
 }
 
 type service struct {
-	desc    *descriptor.ServiceDescriptorProto
-	methods []Method
-	file    File
-	fqn     string
+	desc            *descriptor.ServiceDescriptorProto
+	methods         []Method
+	file            File
+	fqn             string
+	dependentsCache []Entity
 
 	info SourceCodeInfo
 }
@@ -36,7 +37,13 @@ func (s *service) File() File                                     { return s.fil
 func (s *service) BuildTarget() bool                              { return s.file.BuildTarget() }
 func (s *service) SourceCodeInfo() SourceCodeInfo                 { return s.info }
 func (s *service) Descriptor() *descriptor.ServiceDescriptorProto { return s.desc }
-func (s *service) Dependents() []Entity                           { return append(s.file.Dependents(), s.file) }
+
+func (s *service) Dependents() []Entity {
+	if len(s.dependentsCache) == 0 {
+		s.dependentsCache = append(s.file.Dependents(), s.file)
+	}
+	return s.dependentsCache
+}
 
 func (s *service) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
 	return extension(s.desc.GetOptions(), desc, &ext)

--- a/service_test.go
+++ b/service_test.go
@@ -106,6 +106,18 @@ func TestService_Methods(t *testing.T) {
 	assert.Len(t, s.Methods(), 1)
 }
 
+func TestService_Dependents(t *testing.T) {
+	t.Parallel()
+
+	s := &service{}
+	f := dummyFile()
+	f.addService(s)
+	deps := s.Dependents()
+
+	assert.Len(t, deps, 1)
+	assert.Equal(t, f.Name().String(), deps[0].Name().String())
+}
+
 func TestService_Accept(t *testing.T) {
 	t.Parallel()
 

--- a/workflow.go
+++ b/workflow.go
@@ -38,7 +38,7 @@ func (wf *standardWorkflow) Init(g *Generator) AST {
 		pm(wf.params)
 	}
 
-	return ProcessCodeGeneratorRequest(g, req)
+	return ProcessCodeGeneratorRequest(g, req, false)
 }
 
 func (wf *standardWorkflow) Run(ast AST) (arts []Artifact) {

--- a/workflow.go
+++ b/workflow.go
@@ -38,7 +38,7 @@ func (wf *standardWorkflow) Init(g *Generator) AST {
 		pm(wf.params)
 	}
 
-	return ProcessCodeGeneratorRequest(g, req, false)
+	return ProcessCodeGeneratorRequest(g, req)
 }
 
 func (wf *standardWorkflow) Run(ast AST) (arts []Artifact) {


### PR DESCRIPTION
This PR updates the `Entity` interface to include a reference to a given Entity's dependents (Entities that require the given Entity) via `Dependents()`. Basic dependents (direct parents/ancestors) will be always be available, but a full list of dependents will only be accessible if the AST was constructed by `ProcessCodeGeneratorRequestBidirectional` or `ProcessFileDescriptorSetBidirectional`. The full list of dependents includes places where the Entity was imported or used as a field type.

The slice of dependent entities is cached on a given Entity on the first call to `Dependents()` to ensure that the complete list of dependents is cached. This cannot be done during hydration as the dependent references outside of basic dependents is primarily built after everything is hydrated.

This PR also updates the file level dependency logic so that it occurs during file hydration rather than after everything has been hydrated.

todo:
- add test for a message w/ a cyclical reference
- see if cacheing can be improved
- fix AST tests since file logic changed