### PR TITLE
add file, enum, and message dependents

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -78,6 +78,15 @@ func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorReq
 	return g
 }
 
+// ProcessCodeGeneratorRequestBidirectional has the same functionality as
+// ProcessCodeGeneratorRequest, but builds the AST to have references to any
+// entities that depend on them.
+func ProcessCodeGeneratorRequestBidirectional(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST {
+	g := ProcessCodeGeneratorRequest(debug, req)
+	// TODO: fill out deps stuff for messages/enums
+	return g
+}
+
 // ProcessFileDescriptorSet conversts a FileDescriptorSet from protoc into a
 // fully connected AST entity graph. An error is returned if the input is
 // malformed or missing dependencies. To generate a self-contained
@@ -91,6 +100,14 @@ func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorReq
 func ProcessFileDescriptorSet(debug Debugger, fdset *descriptor.FileDescriptorSet) AST {
 	req := plugin_go.CodeGeneratorRequest{ProtoFile: fdset.File}
 	return ProcessCodeGeneratorRequest(debug, &req)
+}
+
+// ProcessFileDescriptorSetBidirectional has the same functionality as
+// ProcessFileDescriptorSet, but builds the AST to have references to any
+// entities that depend on them.
+func ProcessFileDescriptorSetBidirectional(debug Debugger, fdset *descriptor.FileDescriptorSet) AST {
+	req := plugin_go.CodeGeneratorRequest{ProtoFile: fdset.File}
+	return ProcessCodeGeneratorRequestBidirectional(debug, &req)
 }
 
 func (g *graph) hydratePackage(f *descriptor.FileDescriptorProto) Package {

--- a/dependents.go
+++ b/dependents.go
@@ -2,7 +2,9 @@ package pgs
 
 // GetDependents takes in a list of a Message or Enum's direct dependents and generates a
 // full list of dependents including transitive dependents. Additionally, this function
-// ensure that the output slice is deduped.
+// ensure that the output slice is deduped. Name is the fully qualified name of any Message
+// that should be excluded from the list of dependents. If there is no such message, set
+// to name to an empty string.
 func GetDependents(directDeps []Message, name string) []Message {
 	set := make(map[string]Message)
 
@@ -13,8 +15,9 @@ func GetDependents(directDeps []Message, name string) []Message {
 		}
 	}
 
-	// ensure that the message calling DedupeDependents is not included
-	delete(set, name)
+	if name != "" {
+		delete(set, name)
+	}
 
 	dependents := make([]Message, 0, len(set))
 	for _, d := range set {

--- a/dependents.go
+++ b/dependents.go
@@ -1,0 +1,25 @@
+package pgs
+
+// GetDependents takes in a list of a Message or Enum's direct dependents and generates a
+// full list of dependents including transitive dependents. Additionally, this function
+// ensure that the output slice is deduped.
+func GetDependents(directDeps []Message, name string) []Message {
+	set := make(map[string]Message)
+
+	for _, d := range directDeps {
+		set[d.FullyQualifiedName()] = d
+		for _, dd := range d.Dependents() {
+			set[dd.FullyQualifiedName()] = dd
+		}
+	}
+
+	// ensure that the message calling DedupeDependents is not included
+	delete(set, name)
+
+	dependents := make([]Message, 0, len(set))
+	for _, d := range set {
+		dependents = append(dependents, d)
+	}
+
+	return dependents
+}

--- a/dependents.go
+++ b/dependents.go
@@ -1,11 +1,11 @@
 package pgs
 
-// GetDependents takes in a list of a Message or Enum's direct dependents and generates a
+// getDependents takes in a list of a Message or Enum's direct dependents and generates a
 // full list of dependents including transitive dependents. Additionally, this function
 // ensure that the output slice is deduped. Name is the fully qualified name of any Message
 // that should be excluded from the list of dependents. If there is no such message, set
 // to name to an empty string.
-func GetDependents(directDeps []Message, name string) []Message {
+func getDependents(directDeps []Message, name string) []Message {
 	set := make(map[string]Message)
 
 	for _, d := range directDeps {

--- a/dependents_test.go
+++ b/dependents_test.go
@@ -1,0 +1,35 @@
+package pgs
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDependents(t *testing.T) {
+	t.Parallel()
+
+	pkg := dummyPkg()
+	f := &file{
+		pkg: pkg,
+		desc: &descriptor.FileDescriptorProto{
+			Package: proto.String(pkg.ProtoName().String()),
+			Syntax:  proto.String(string(Proto3)),
+			Name:    proto.String("test_file.proto"),
+		},
+	}
+
+	m := &msg{parent: f}
+	m.fqn = fullyQualifiedName(f, m)
+	m2 := dummyMsg()
+	deps := GetDependents([]Message{m, m2}, m.FullyQualifiedName())
+
+	assert.Len(t, deps, 1)
+	assert.Contains(t, deps, m2)
+
+	deps = GetDependents([]Message{m, m2}, m2.FullyQualifiedName())
+	assert.Len(t, deps, 1)
+	assert.Contains(t, deps, m)
+}

--- a/dependents_test.go
+++ b/dependents_test.go
@@ -24,6 +24,7 @@ func TestGetDependents(t *testing.T) {
 	m := &msg{parent: f}
 	m.fqn = fullyQualifiedName(f, m)
 	m2 := dummyMsg()
+	m2.fqn = "foo"
 	deps := GetDependents([]Message{m, m2}, m.FullyQualifiedName())
 
 	assert.Len(t, deps, 1)

--- a/dependents_test.go
+++ b/dependents_test.go
@@ -25,12 +25,12 @@ func TestGetDependents(t *testing.T) {
 	m.fqn = fullyQualifiedName(f, m)
 	m2 := dummyMsg()
 	m2.fqn = "foo"
-	deps := GetDependents([]Message{m, m2}, m.FullyQualifiedName())
+	deps := getDependents([]Message{m, m2}, m.FullyQualifiedName())
 
 	assert.Len(t, deps, 1)
 	assert.Contains(t, deps, m2)
 
-	deps = GetDependents([]Message{m, m2}, m2.FullyQualifiedName())
+	deps = getDependents([]Message{m, m2}, m2.FullyQualifiedName())
 	assert.Len(t, deps, 1)
 	assert.Contains(t, deps, m)
 }

--- a/enum.go
+++ b/enum.go
@@ -53,7 +53,7 @@ func (e *enum) Values() []EnumValue                         { return e.vals }
 
 func (e *enum) Dependents() []Message {
 	if e.dependentsCache == nil {
-		e.dependentsCache = GetDependents(e.dependents, e.FullyQualifiedName())
+		e.dependentsCache = GetDependents(e.dependents, "")
 	}
 	return e.dependentsCache
 }

--- a/enum.go
+++ b/enum.go
@@ -53,26 +53,7 @@ func (e *enum) Values() []EnumValue                         { return e.vals }
 
 func (e *enum) Dependents() []Message {
 	if e.dependentsCache == nil {
-		set := make(map[string]Message)
-
-		if parent, ok := e.Parent().(Message); ok {
-			set[parent.FullyQualifiedName()] = parent
-			for _, d := range parent.Dependents() {
-				set[d.FullyQualifiedName()] = d
-			}
-		}
-
-		for _, d := range e.dependents {
-			set[d.FullyQualifiedName()] = d
-			for _, dd := range d.Dependents() {
-				set[dd.FullyQualifiedName()] = dd
-			}
-		}
-
-		e.dependentsCache = make([]Message, 0, len(set))
-		for _, d := range set {
-			e.dependentsCache = append(e.dependentsCache, d)
-		}
+		e.dependentsCache = GetDependents(e.dependents, e.FullyQualifiedName())
 	}
 	return e.dependentsCache
 }

--- a/enum.go
+++ b/enum.go
@@ -20,16 +20,23 @@ type Enum interface {
 	// Values returns each defined enumeration value.
 	Values() []EnumValue
 
+	// Dependents returns all of the messages where Enum is directly or
+	// transitively used.
+	Dependents() []Message
+
 	addValue(v EnumValue)
+	addDependent(m Message)
 	setParent(p ParentEntity)
 }
 
 type enum struct {
-	desc   *descriptor.EnumDescriptorProto
-	parent ParentEntity
-	vals   []EnumValue
-	info   SourceCodeInfo
-	fqn    string
+	desc            *descriptor.EnumDescriptorProto
+	parent          ParentEntity
+	vals            []EnumValue
+	info            SourceCodeInfo
+	fqn             string
+	dependents      []Message
+	dependentsCache []Message
 }
 
 func (e *enum) Name() Name                                  { return Name(e.desc.GetName()) }
@@ -43,6 +50,32 @@ func (e *enum) Descriptor() *descriptor.EnumDescriptorProto { return e.desc }
 func (e *enum) Parent() ParentEntity                        { return e.parent }
 func (e *enum) Imports() []File                             { return nil }
 func (e *enum) Values() []EnumValue                         { return e.vals }
+
+func (e *enum) Dependents() []Message {
+	if e.dependentsCache == nil {
+		set := make(map[string]Message)
+
+		if parent, ok := e.Parent().(Message); ok {
+			set[parent.FullyQualifiedName()] = parent
+			for _, d := range parent.Dependents() {
+				set[d.FullyQualifiedName()] = d
+			}
+		}
+
+		for _, d := range e.dependents {
+			set[d.FullyQualifiedName()] = d
+			for _, dd := range d.Dependents() {
+				set[dd.FullyQualifiedName()] = dd
+			}
+		}
+
+		e.dependentsCache = make([]Message, 0, len(set))
+		for _, d := range set {
+			e.dependentsCache = append(e.dependentsCache, d)
+		}
+	}
+	return e.dependentsCache
+}
 
 func (e *enum) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
 	return extension(e.desc.GetOptions(), desc, &ext)
@@ -64,6 +97,10 @@ func (e *enum) accept(v Visitor) (err error) {
 	}
 
 	return
+}
+
+func (e *enum) addDependent(m Message) {
+	e.dependents = append(e.dependents, m)
 }
 
 func (e *enum) addValue(v EnumValue) {

--- a/enum.go
+++ b/enum.go
@@ -53,7 +53,7 @@ func (e *enum) Values() []EnumValue                         { return e.vals }
 
 func (e *enum) Dependents() []Message {
 	if e.dependentsCache == nil {
-		e.dependentsCache = GetDependents(e.dependents, "")
+		e.dependentsCache = getDependents(e.dependents, "")
 	}
 	return e.dependentsCache
 }

--- a/enum_test.go
+++ b/enum_test.go
@@ -117,17 +117,27 @@ func TestEnum_Dependents(t *testing.T) {
 		e := &enum{}
 		m := dummyMsg()
 		m.addEnum(e)
-		deps := e.Dependents()
 
-		assert.Len(t, deps, 1)
-		assert.Contains(t, deps, m)
+		assert.Empty(t, e.Dependents())
 	})
 
 	t.Run("external dependents", func(t *testing.T) {
 		t.Parallel()
 
+		pkg := dummyPkg()
+		f := &file{
+			pkg: pkg,
+			desc: &descriptor.FileDescriptorProto{
+				Package: proto.String(pkg.ProtoName().String()),
+				Syntax:  proto.String(string(Proto3)),
+				Name:    proto.String("test_file.proto"),
+			},
+		}
+
 		e := &enum{}
+		e.fqn = fullyQualifiedName(f, e)
 		m := dummyMsg()
+		m.fqn = fullyQualifiedName(f, m)
 		e.addDependent(m)
 		deps := e.Dependents()
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -98,6 +98,44 @@ func TestEnum_Values(t *testing.T) {
 	assert.Len(t, e.Values(), 1)
 }
 
+func TestEnum_Dependents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enum in file", func(t *testing.T) {
+		t.Parallel()
+
+		e := &enum{}
+		f := dummyFile()
+		f.addEnum(e)
+
+		assert.Empty(t, e.Dependents())
+	})
+
+	t.Run("enum in message", func(t *testing.T) {
+		t.Parallel()
+
+		e := &enum{}
+		m := dummyMsg()
+		m.addEnum(e)
+		deps := e.Dependents()
+
+		assert.Len(t, deps, 1)
+		assert.Contains(t, deps, m)
+	})
+
+	t.Run("external dependents", func(t *testing.T) {
+		t.Parallel()
+
+		e := &enum{}
+		m := dummyMsg()
+		e.addDependent(m)
+		deps := e.Dependents()
+
+		assert.Len(t, deps, 1)
+		assert.Contains(t, deps, m)
+	})
+}
+
 func TestEnum_Extension(t *testing.T) {
 	// cannot be parallel
 

--- a/file.go
+++ b/file.go
@@ -16,6 +16,8 @@ type File interface {
 	// Descriptor returns the underlying descriptor for the proto file
 	Descriptor() *descriptor.FileDescriptorProto
 
+	// Dependents returns all files where the given file was directly or
+	// transitively imported.
 	Dependents() []File
 
 	// Services returns the services from this proto file.

--- a/file.go
+++ b/file.go
@@ -16,6 +16,8 @@ type File interface {
 	// Descriptor returns the underlying descriptor for the proto file
 	Descriptor() *descriptor.FileDescriptorProto
 
+	Dependents() []File
+
 	// Services returns the services from this proto file.
 	Services() []Service
 
@@ -29,7 +31,9 @@ type File interface {
 
 	setPackage(p Package)
 
-	addFileDep(fl File)
+	addFileDependency(fl File)
+
+	addDependent(fl File)
 
 	addService(s Service)
 
@@ -42,7 +46,9 @@ type file struct {
 	pkg                     Package
 	enums                   []Enum
 	defExts                 []Extension
-	fileDeps                []File
+	dependents              []File
+	dependentsCache         []File
+	fileDependencies        []File
 	msgs                    []Message
 	srvs                    []Service
 	buildTarget             bool
@@ -93,7 +99,7 @@ func (f *file) Services() []Service {
 func (f *file) Imports() (i []File) {
 	// Mapping for avoiding duplicate entries
 	importMap := make(map[string]File, len(f.AllMessages())+len(f.srvs))
-	for _, fl := range f.fileDeps {
+	for _, fl := range f.fileDependencies {
 		importMap[fl.Name().String()] = fl
 	}
 	for _, m := range f.AllMessages() {
@@ -110,6 +116,24 @@ func (f *file) Imports() (i []File) {
 		i = append(i, imp)
 	}
 	return
+}
+
+func (f *file) Dependents() []File {
+	if f.dependentsCache == nil {
+		set := make(map[string]File)
+		for _, fl := range f.dependents {
+			set[fl.Name().String()] = fl
+			for _, d := range fl.Dependents() {
+				set[d.Name().String()] = d
+			}
+		}
+
+		f.dependentsCache = make([]File, 0, len(set))
+		for _, d := range set {
+			f.dependentsCache = append(f.dependentsCache, d)
+		}
+	}
+	return f.dependentsCache
 }
 
 func (f *file) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, error) {
@@ -167,8 +191,12 @@ func (f *file) addEnum(e Enum) {
 	f.enums = append(f.enums, e)
 }
 
-func (f *file) addFileDep(fl File) {
-	f.fileDeps = append(f.fileDeps, fl)
+func (f *file) addFileDependency(fl File) {
+	f.fileDependencies = append(f.fileDependencies, fl)
+}
+
+func (f *file) addDependent(fl File) {
+	f.dependents = append(f.dependents, fl)
 }
 
 func (f *file) addMessage(m Message) {

--- a/file_test.go
+++ b/file_test.go
@@ -164,7 +164,7 @@ func TestFile_Imports(t *testing.T) {
 
 	f.addMessage(m)
 	f.addService(svc)
-	f.addFileDep(flDep)
+	f.addFileDependency(flDep)
 	assert.Len(t, f.Imports(), 2)
 
 	nf := &file{desc: &descriptor.FileDescriptorProto{
@@ -172,6 +172,18 @@ func TestFile_Imports(t *testing.T) {
 	}}
 	f.addMessage(&mockMessage{i: []File{nf}, Message: &msg{}})
 	assert.Len(t, f.Imports(), 3)
+}
+
+func TestFile_Dependents(t *testing.T) {
+	t.Parallel()
+
+	f := &file{}
+	fl := dummyFile()
+	f.addDependent(fl)
+	deps := f.Dependents()
+
+	assert.Len(t, deps, 1)
+	assert.Contains(t, deps, fl)
 }
 
 func TestFile_Accept(t *testing.T) {

--- a/message.go
+++ b/message.go
@@ -154,29 +154,7 @@ func (m *msg) Imports() (i []File) {
 
 func (m *msg) Dependents() []Message {
 	if m.dependentsCache == nil {
-		set := make(map[string]Message)
-
-		if parent, ok := m.Parent().(Message); ok {
-			set[parent.FullyQualifiedName()] = parent
-			for _, d := range parent.Dependents() {
-				set[d.FullyQualifiedName()] = d
-			}
-		}
-
-		for _, d := range m.dependents {
-			set[d.FullyQualifiedName()] = d
-			for _, dd := range d.Dependents() {
-				set[dd.FullyQualifiedName()] = dd
-			}
-		}
-
-		// prevent m from adding itself to its dependents
-		delete(set, m.FullyQualifiedName())
-
-		m.dependentsCache = make([]Message, 0, len(set))
-		for _, d := range set {
-			m.dependentsCache = append(m.dependentsCache, d)
-		}
+		m.dependentsCache = GetDependents(m.dependents, m.FullyQualifiedName())
 	}
 	return m.dependentsCache
 }

--- a/message.go
+++ b/message.go
@@ -154,7 +154,7 @@ func (m *msg) Imports() (i []File) {
 
 func (m *msg) Dependents() []Message {
 	if m.dependentsCache == nil {
-		m.dependentsCache = GetDependents(m.dependents, m.FullyQualifiedName())
+		m.dependentsCache = getDependents(m.dependents, m.FullyQualifiedName())
 	}
 	return m.dependentsCache
 }

--- a/message.go
+++ b/message.go
@@ -170,6 +170,9 @@ func (m *msg) Dependents() []Message {
 			}
 		}
 
+		// prevent m from adding itself to its dependents
+		delete(set, m.FullyQualifiedName())
+
 		m.dependentsCache = make([]Message, 0, len(set))
 		for _, d := range set {
 			m.dependentsCache = append(m.dependentsCache, d)

--- a/message_test.go
+++ b/message_test.go
@@ -352,31 +352,14 @@ func TestMsg_Dependents(t *testing.T) {
 		},
 	}
 
-	t.Run("no external deps", func(t *testing.T) {
-		t.Parallel()
+	m := &msg{parent: f}
+	m.fqn = fullyQualifiedName(f, m)
+	m2 := dummyMsg()
+	m.addDependent(m2)
+	deps := m.Dependents()
 
-		m := &msg{parent: f}
-		m.fqn = fullyQualifiedName(f, m)
-		p := dummyMsg()
-		p.addMessage(m)
-		deps := m.Dependents()
-
-		assert.Len(t, deps, 1)
-		assert.Contains(t, deps, p)
-	})
-
-	t.Run("external deps", func(t *testing.T) {
-		t.Parallel()
-
-		m := &msg{parent: f}
-		m.fqn = fullyQualifiedName(f, m)
-		m2 := dummyMsg()
-		m.addDependent(m2)
-		deps := m.Dependents()
-
-		assert.Len(t, deps, 1)
-		assert.Contains(t, deps, m2)
-	})
+	assert.Len(t, deps, 1)
+	assert.Contains(t, deps, m2)
 }
 
 func TestMsg_ChildAtPath(t *testing.T) {

--- a/message_test.go
+++ b/message_test.go
@@ -342,10 +342,21 @@ func TestMsg_Imports(t *testing.T) {
 func TestMsg_Dependents(t *testing.T) {
 	t.Parallel()
 
+	pkg := dummyPkg()
+	f := &file{
+		pkg: pkg,
+		desc: &descriptor.FileDescriptorProto{
+			Package: proto.String(pkg.ProtoName().String()),
+			Syntax:  proto.String(string(Proto3)),
+			Name:    proto.String("test_file.proto"),
+		},
+	}
+
 	t.Run("no external deps", func(t *testing.T) {
 		t.Parallel()
 
-		m := &msg{}
+		m := &msg{parent: f}
+		m.fqn = fullyQualifiedName(f, m)
 		p := dummyMsg()
 		p.addMessage(m)
 		deps := m.Dependents()
@@ -357,7 +368,8 @@ func TestMsg_Dependents(t *testing.T) {
 	t.Run("external deps", func(t *testing.T) {
 		t.Parallel()
 
-		m := &msg{}
+		m := &msg{parent: f}
+		m.fqn = fullyQualifiedName(f, m)
 		m2 := dummyMsg()
 		m.addDependent(m2)
 		deps := m.Dependents()

--- a/message_test.go
+++ b/message_test.go
@@ -339,6 +339,34 @@ func TestMsg_Imports(t *testing.T) {
 	assert.Len(t, m.Imports(), 2)
 }
 
+func TestMsg_Dependents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no external deps", func(t *testing.T) {
+		t.Parallel()
+
+		m := &msg{}
+		p := dummyMsg()
+		p.addMessage(m)
+		deps := m.Dependents()
+
+		assert.Len(t, deps, 1)
+		assert.Contains(t, deps, p)
+	})
+
+	t.Run("external deps", func(t *testing.T) {
+		t.Parallel()
+
+		m := &msg{}
+		m2 := dummyMsg()
+		m.addDependent(m2)
+		deps := m.Dependents()
+
+		assert.Len(t, deps, 1)
+		assert.Contains(t, deps, m2)
+	})
+}
+
 func TestMsg_ChildAtPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR updates the File, Message, and Enum interfaces to include a reference to their dependents (Entities that require the given Entity) via Dependents(). File dependents are any file that directly or transitively imports the file. Message and enum dependents are any Message where it was used directly or transitively. 

A file's dependents will be always be available, but a full list of dependents for messages and enums will only be accessible if the AST was constructed by ProcessCodeGeneratorRequestBidirectional or ProcessFileDescriptorSetBidirectional. 

The slice of dependent messages is cached on a given Enum/Message on the first call to Dependents() to ensure that the complete list of dependents is cached. This cannot be done during hydration as the dependent references outside of basic dependents is primarily built after everything is hydrated.

This PR also updates the file level dependency logic so that it occurs during file hydration rather than after everything has been hydrated.