### PR TITLE
lang/go: Add TypeName.IsPointer()

### DIFF
--- a/lang/go/type_name.go
+++ b/lang/go/type_name.go
@@ -110,17 +110,21 @@ func (n TypeName) Key() TypeName {
 	return TypeName(parts[1])
 }
 
+// IsPointer reports whether TypeName n is a pointer type, slice or a map.
+func (n TypeName) IsPointer() bool {
+	ns := string(n)
+	return strings.HasPrefix(ns, "*") ||
+		strings.HasPrefix(ns, "[") ||
+		strings.HasPrefix(ns, "map[")
+}
+
 // Pointer converts TypeName n to it's pointer type. If n is already a pointer,
 // slice, or map, it is returned unmodified.
 func (n TypeName) Pointer() TypeName {
-	ns := string(n)
-	if strings.HasPrefix(ns, "*") ||
-		strings.HasPrefix(ns, "[") ||
-		strings.HasPrefix(ns, "map[") {
+	if n.IsPointer() {
 		return n
 	}
-
-	return TypeName("*" + ns)
+	return TypeName("*" + string(n))
 }
 
 // Value converts TypeName n to it's value type. If n is already a value type,

--- a/lang/go/type_name_test.go
+++ b/lang/go/type_name_test.go
@@ -241,6 +241,11 @@ func TestTypeName(t *testing.T) {
 				assert.Equal(t, tc.key, tn.Key().String())
 			})
 
+			t.Run("IsPointer", func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.ptr == tc.in, tn.IsPointer())
+			})
+
 			t.Run("Pointer", func(t *testing.T) {
 				t.Parallel()
 				assert.Equal(t, tc.ptr, tn.Pointer().String())
@@ -303,6 +308,25 @@ func ExampleTypeName_Key() {
 	//
 	// int
 	// string
+}
+
+func ExampleTypeName_IsPointer() {
+	types := []string{
+		"int",
+		"*my.Type",
+		"[]string",
+		"map[string]*io.Reader",
+	}
+
+	for _, t := range types {
+		fmt.Println(TypeName(t).IsPointer())
+	}
+
+	// Output:
+	// false
+	// true
+	// true
+	// true
 }
 
 func ExampleTypeName_Pointer() {


### PR DESCRIPTION
Export `TypeName.IsPointer()`, which can be quite useful in various scenarios.
Extracted from #51 