### PR TITLE
Add "CodeGeneratorRequest" access in BuildContext

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -21,10 +21,14 @@ type AST interface {
 	// (FQN). The FQN uses dot notation of the form ".{package}.{entity}", or the
 	// input path for Files.
 	Lookup(name string) (Entity, bool)
+
+	// The original CodeGeneratorRequest from protoc
+    CodeGeneratorRequest() *plugin_go.CodeGeneratorRequest
 }
 
 type graph struct {
 	d Debugger
+    req *plugin_go.CodeGeneratorRequest
 
 	targets    map[string]File
 	packages   map[string]Package
@@ -41,6 +45,8 @@ func (g *graph) Lookup(name string) (Entity, bool) {
 	return e, ok
 }
 
+func (g *graph) CodeGeneratorRequest() *plugin_go.CodeGeneratorRequest { return g.req }
+
 // ProcessDescriptors is deprecated; use ProcessCodeGeneratorRequest instead
 func ProcessDescriptors(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST {
 	return ProcessCodeGeneratorRequest(debug, req)
@@ -51,6 +57,7 @@ func ProcessDescriptors(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST
 func ProcessCodeGeneratorRequest(debug Debugger, req *plugin_go.CodeGeneratorRequest) AST {
 	g := &graph{
 		d:          debug,
+		req:        req,
 		targets:    make(map[string]File, len(req.GetFileToGenerate())),
 		packages:   make(map[string]Package),
 		entities:   make(map[string]Entity),

--- a/workflow.go
+++ b/workflow.go
@@ -49,7 +49,7 @@ func (wf *standardWorkflow) Init(g *Generator) AST {
 }
 
 func (wf *standardWorkflow) Run(ast AST) (arts []Artifact) {
-	ctx := Context(wf.Debugger, wf.params, wf.params.OutputPath())
+	ctx := Context(wf.Debugger, wf.params, wf.params.OutputPath(), ast.CodeGeneratorRequest())
 
 	wf.Debug("initializing modules")
 	for _, m := range wf.mods {


### PR DESCRIPTION
While this plugin's abstraction of the CodeGeneratorRequest is the main purpose of the plugin, there are times it's necessary to get the original CodeGeneratorRequest that was parsed from stdin.

In regards to the https://github.com/srikrsna/protoc-gen-gotag project

The purpose of this project is to add functionality on top of the "protoc-gen-go" standard plugin by adding tags on to the generated go code.   Because the original CodeGeneratorRequest is not available during the module execution, the generated code from the protoc-gen-go plugin must have already been written to disk. This means that you cannot both use the protoc-gen-go plugin and the protoc-gen-gotag plugin in the same execution of protoc. Even worse, if it is not in the current directory of the execution,  the module.needs additional parameters to point to the output location.  

This could be alleviated by having access to the original CodeGeneratorRequest.  If that was available, we could use it to get the CodeGeneratorResponse from the official protoc-gen-go library then enhance it and output the results.

This pull request exposes the original CodeGeneratorRequest as part of the BuildContext