### PR TITLE
persister: fix append files

### DIFF
--- a/persister.go
+++ b/persister.go
@@ -98,6 +98,24 @@ func (p *stdPersister) Persist(arts ...Artifact) *plugin_go.CodeGeneratorRespons
 	return resp
 }
 
+func (p *stdPersister) tailOfFile(resp *plugin_go.CodeGeneratorResponse, name string) int {
+	tail := p.indexOfFile(resp, name)
+
+	if tail == -1 {
+		return -1
+	}
+
+	f := resp.GetFile()
+	for i := tail + 1; i < len(f); i++ {
+		if f[i].GetName() != "" {
+			break
+		}
+		tail = i
+	}
+
+	return tail
+}
+
 func (p *stdPersister) indexOfFile(resp *plugin_go.CodeGeneratorResponse, name string) int {
 	for i, f := range resp.GetFile() {
 		if f.GetName() == name && f.InsertionPoint == nil {
@@ -122,7 +140,7 @@ func (p *stdPersister) insertFile(resp *plugin_go.CodeGeneratorResponse,
 
 func (p *stdPersister) insertAppend(resp *plugin_go.CodeGeneratorResponse,
 	name string, f *plugin_go.CodeGeneratorResponse_File) {
-	i := p.indexOfFile(resp, name)
+	i := p.tailOfFile(resp, name)
 	p.Assert(i > -1, "append target ", name, " missing")
 
 	resp.File = append(

--- a/persister_test.go
+++ b/persister_test.go
@@ -121,6 +121,35 @@ func TestPersister_Persist_GeneratorAppend(t *testing.T) {
 	assert.True(t, d.Failed())
 }
 
+func TestPersister_Persist_GeneratorAppendSeveral(t *testing.T) {
+	t.Parallel()
+
+	d := InitMockDebugger()
+	p := dummyPersister(d)
+	fs := afero.NewMemMapFs()
+	p.SetFS(fs)
+
+	resp := p.Persist(
+		GeneratorFile{
+			Name:     "file",
+			Contents: "foo",
+		},
+		GeneratorAppend{
+			FileName: "file",
+			Contents: "bar",
+		},
+		GeneratorAppend{
+			FileName: "file",
+			Contents: "baz",
+		},
+	)
+
+	assert.Len(t, resp.File, 3)
+	assert.Equal(t, "foo", resp.File[0].GetContent())
+	assert.Equal(t, "bar", resp.File[1].GetContent())
+	assert.Equal(t, "baz", resp.File[2].GetContent())
+}
+
 func TestPersister_Persist_GeneratorTemplateAppend(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixed `insertAppend` to insert artifacts at the end of the file.
This is a fix proposal for #73 