### PR TITLE
file.imports() pulls in all transitive dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: "1.11"
+go: "1.12.8"
 go_import_path: github.com/lyft/protoc-gen-star
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ lint: # lints the package for common code smells
 	done
 	which golint || go get -u golang.org/x/lint/golint
 	golint -set_exit_status $(PKGS)
-	go vet -all -shadowstrict $(PKGS)
+	go get -u golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+	go vet -all -vettool=$(which shadow)
 
 .PHONY: quick
 quick: vendor testdata # runs all tests without the race detector or coverage

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint: # lints the package for common code smells
 	done
 	which golint || go get -u golang.org/x/lint/golint
 	golint -set_exit_status $(PKGS)
-	go vet -all -shadow -shadowstrict $(PKGS)
+	go vet -all -shadowstrict $(PKGS)
 
 .PHONY: quick
 quick: vendor testdata # runs all tests without the race detector or coverage

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ lint: # lints the package for common code smells
 	done
 	which golint || go get -u golang.org/x/lint/golint
 	golint -set_exit_status $(PKGS)
-	go get -u golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-	go vet -all -vettool=$(which shadow)
+	go vet -all
 
 .PHONY: quick
 quick: vendor testdata # runs all tests without the race detector or coverage

--- a/ast.go
+++ b/ast.go
@@ -144,7 +144,6 @@ func (g *graph) hydrateFile(pkg Package, f *descriptor.FileDescriptorProto) File
 	}
 	g.add(fl)
 
-	fl.fileDependencies = make([]File, 0)
 	for _, dep := range f.GetDependency() {
 		// the AST is built in topological order so a file's dependencies are always hydrated first
 		d := g.mustSeen(dep).(File)

--- a/ast.go
+++ b/ast.go
@@ -144,6 +144,7 @@ func (g *graph) hydrateFile(pkg Package, f *descriptor.FileDescriptorProto) File
 	}
 	g.add(fl)
 
+	fl.fileDependencies = make([]File, 0)
 	for _, dep := range f.GetDependency() {
 		// the AST is built in topological order so a file's dependencies are always hydrated first
 		d := g.mustSeen(dep).(File)
@@ -191,8 +192,6 @@ func (g *graph) hydrateFile(pkg Package, f *descriptor.FileDescriptorProto) File
 			fld.addType(g.hydrateFieldType(fld))
 		}
 	}
-
-	fl.fileDependencies = make([]File, 0)
 
 	g.hydrateSourceCodeInfo(fl, f)
 

--- a/ast_test.go
+++ b/ast_test.go
@@ -321,6 +321,11 @@ func TestGraph_Extensions(t *testing.T) {
 	assert.NotNil(t, ent.(File).DefinedExtensions())
 	assert.Len(t, ent.(File).DefinedExtensions(), 6)
 
+	ent, ok = g.Lookup("extensions/everything.proto")
+	assert.True(t, ok)
+	assert.NotNil(t, ent.(File).DefinedExtensions())
+	assert.Len(t, ent.(File).Imports(), 4)
+
 	ent, ok = g.Lookup(".extensions.Request")
 	assert.True(t, ok)
 	assert.NotNil(t, ent.(Message).DefinedExtensions())

--- a/ast_test.go
+++ b/ast_test.go
@@ -1,6 +1,7 @@
 package pgs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -324,7 +325,9 @@ func TestGraph_Extensions(t *testing.T) {
 	ent, ok = g.Lookup("extensions/everything.proto")
 	assert.True(t, ok)
 	assert.NotNil(t, ent.(File).DefinedExtensions())
-	assert.Len(t, ent.(File).Imports(), 4)
+	fmt.Println(len(ent.(File).Imports()))                    // currently 1
+	fmt.Println(len(ent.(File).Descriptor().GetDependency())) // currently 4
+	//assert.Len(t, ent.(File).Imports(), 4)
 
 	ent, ok = g.Lookup(".extensions.Request")
 	assert.True(t, ok)

--- a/ast_test.go
+++ b/ast_test.go
@@ -1,7 +1,6 @@
 package pgs
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -325,9 +324,7 @@ func TestGraph_Extensions(t *testing.T) {
 	ent, ok = g.Lookup("extensions/everything.proto")
 	assert.True(t, ok)
 	assert.NotNil(t, ent.(File).DefinedExtensions())
-	fmt.Println(len(ent.(File).Imports()))                    // currently 1
-	fmt.Println(len(ent.(File).Descriptor().GetDependency())) // currently 4
-	//assert.Len(t, ent.(File).Imports(), 4)
+	assert.Len(t, ent.(File).Imports(), 4)
 
 	ent, ok = g.Lookup(".extensions.Request")
 	assert.True(t, ok)

--- a/file.go
+++ b/file.go
@@ -103,17 +103,7 @@ func (f *file) Imports() (i []File) {
 	importMap := make(map[string]File, len(f.AllMessages())+len(f.srvs))
 	for _, fl := range f.fileDependencies {
 		importMap[fl.Name().String()] = fl
-		//for _, imp := range fl.Imports() {
-		//	importMap[imp.File().Name().String()] = imp
-		//}
-	}
-	for _, m := range f.AllMessages() {
-		for _, imp := range m.Imports() {
-			importMap[imp.File().Name().String()] = imp
-		}
-	}
-	for _, s := range f.srvs {
-		for _, imp := range s.Imports() {
+		for _, imp := range fl.Imports() {
 			importMap[imp.File().Name().String()] = imp
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -103,9 +103,9 @@ func (f *file) Imports() (i []File) {
 	importMap := make(map[string]File, len(f.AllMessages())+len(f.srvs))
 	for _, fl := range f.fileDependencies {
 		importMap[fl.Name().String()] = fl
-		for _, imp := range fl.Imports() {
-			importMap[imp.File().Name().String()] = imp
-		}
+		//for _, imp := range fl.Imports() {
+		//	importMap[imp.File().Name().String()] = imp
+		//}
 	}
 	for _, m := range f.AllMessages() {
 		for _, imp := range m.Imports() {

--- a/file.go
+++ b/file.go
@@ -103,6 +103,9 @@ func (f *file) Imports() (i []File) {
 	importMap := make(map[string]File, len(f.AllMessages())+len(f.srvs))
 	for _, fl := range f.fileDependencies {
 		importMap[fl.Name().String()] = fl
+		for _, imp := range fl.Imports() {
+			importMap[imp.File().Name().String()] = imp
+		}
 	}
 	for _, m := range f.AllMessages() {
 		for _, imp := range m.Imports() {

--- a/file_test.go
+++ b/file_test.go
@@ -154,24 +154,17 @@ func TestFile_Services(t *testing.T) {
 func TestFile_Imports(t *testing.T) {
 	t.Parallel()
 
-	m := &msg{}
-	m.addMessage(&mockMessage{i: []File{&file{}}, Message: &msg{}})
-	svc := &mockService{i: []File{&file{}}, Service: &service{}}
 	flDep := dummyFile()
+	nf := &file{desc: &descriptor.FileDescriptorProto{
+		Name: proto.String("foobar"),
+	}}
+	flDep.addFileDependency(nf)
 
 	f := &file{}
 	assert.Empty(t, f.Imports())
 
-	f.addMessage(m)
-	f.addService(svc)
 	f.addFileDependency(flDep)
 	assert.Len(t, f.Imports(), 2)
-
-	nf := &file{desc: &descriptor.FileDescriptorProto{
-		Name: proto.String("foobar"),
-	}}
-	f.addMessage(&mockMessage{i: []File{nf}, Message: &msg{}})
-	assert.Len(t, f.Imports(), 3)
 }
 
 func TestFile_Dependents(t *testing.T) {


### PR DESCRIPTION
## context
this PR fixes two bugs related to file.imports() and simplifies pulling in a file's dependencies
- file.imports() will now pull in all transitive dependencies, rather than just immediate dependencies
- file.imports() correctly pulls in all immediate dependencies via file.descriptor.GetDependency() removing the need to check a file's messages and services for additional imports
- updates `go vet` command and go version https://golang.org/doc/go1.12#vet