### PR TITLE
Fix import path behaviour when using full path

### DIFF
--- a/lang/go/package.go
+++ b/lang/go/package.go
@@ -23,6 +23,10 @@ func (c context) PackageName(node pgs.Node) pgs.Name {
 	// use import_path parameter ONLY if there is no go_package option in the file.
 	if ip := c.p.Str("import_path"); ip != "" &&
 		e.File().Descriptor().GetOptions().GetGoPackage() == "" {
+		// Remove anything before the last slash
+		if i := strings.LastIndex(ip, "/"); i >= 0 {
+			ip = ip[i+1:]
+		}
 		pkg = ip
 	}
 

--- a/lang/go/package_test.go
+++ b/lang/go/package_test.go
@@ -22,6 +22,7 @@ func TestPackageName(t *testing.T) {
 		{"import", "bar"},                    // uses the basename if go_package contains a /
 		{"override", "baz"},                  // if go_package contains ;, use everything to the right
 		{"import_path", "_package"},          // import_path param used if no go_package option
+		{"full_import_path", "buzz"},         // import_path param used if no go_package option. Should use last part of path.
 		{"mapped", "unaffected"},             // M mapped params are ignored for build targets
 		{"import_path_mapped", "go_package"}, // mixed import_path and M parameters should lose to go_package
 		{"transitive_package", "foobar"},     // go_option gets picked up from other files if present

--- a/lang/go/testdata/names/full_import_path/import_path.proto
+++ b/lang/go/testdata/names/full_import_path/import_path.proto
@@ -1,0 +1,4 @@
+syntax="proto3";
+package names.import_path;
+
+message ImportPath {}

--- a/lang/go/testdata/names/full_import_path/params
+++ b/lang/go/testdata/names/full_import_path/params
@@ -1,0 +1,1 @@
+Mnames/import_path/import_path.proto=foobar,import_path=github.com/fizz/buzz


### PR DESCRIPTION
This change makes `protoc-gen-star` conform to the behaviour of `protoc-gen-go` in the presence of an `import_path` parameter that contains slashes.

See https://github.com/golang/protobuf/blob/v1.4.2/protoc-gen-go/generator/generator.go#L637-L643
for evidence of this behaviour in `protoc-gen-go`.

Fixes #77