### PR TITLE
Make Imports consistent; add TransitiveImports for the whole tree

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -24,7 +24,8 @@ type Entity interface {
 	// Package returns the container package for this entity.
 	Package() Package
 
-	// Imports includes all external files required by this entity.
+	// Imports includes external files directly required by this entity. Call
+	// TransitiveImports on File to get all transitive dependencies.
 	Imports() []File
 
 	// File returns the File containing this entity.

--- a/file.go
+++ b/file.go
@@ -16,6 +16,10 @@ type File interface {
 	// Descriptor returns the underlying descriptor for the proto file
 	Descriptor() *descriptor.FileDescriptorProto
 
+	// TransitiveImports returns all direct and transitive dependencies of this
+	// File. Use Imports to obtain only direct dependencies.
+	TransitiveImports() []File
+
 	// Dependents returns all files where the given file was directly or
 	// transitively imported.
 	Dependents() []File
@@ -98,19 +102,27 @@ func (f *file) Services() []Service {
 	return f.srvs
 }
 
-func (f *file) Imports() (i []File) {
-	// Mapping for avoiding duplicate entries
-	importMap := make(map[string]File, len(f.AllMessages())+len(f.srvs))
+func (f *file) Imports() []File {
+	out := make([]File, len(f.fileDependencies))
+	copy(out, f.fileDependencies)
+	return out
+}
+
+func (f *file) TransitiveImports() []File {
+	importMap := make(map[string]File, len(f.fileDependencies))
 	for _, fl := range f.fileDependencies {
 		importMap[fl.Name().String()] = fl
-		for _, imp := range fl.Imports() {
+		for _, imp := range fl.TransitiveImports() {
 			importMap[imp.File().Name().String()] = imp
 		}
 	}
+
+	out := make([]File, 0, len(importMap))
 	for _, imp := range importMap {
-		i = append(i, imp)
+		out = append(out, imp)
 	}
-	return
+
+	return out
 }
 
 func (f *file) Dependents() []File {

--- a/file_test.go
+++ b/file_test.go
@@ -163,7 +163,23 @@ func TestFile_Imports(t *testing.T) {
 	assert.Empty(t, f.Imports())
 
 	f.addFileDependency(flDep)
-	assert.Len(t, f.Imports(), 2)
+	assert.Len(t, f.Imports(), 1)
+}
+
+func TestFile_TransitiveImports(t *testing.T) {
+	t.Parallel()
+
+	flDep := dummyFile()
+	nf := &file{desc: &descriptor.FileDescriptorProto{
+		Name: proto.String("foobar"),
+	}}
+	flDep.addFileDependency(nf)
+
+	f := &file{}
+	assert.Empty(t, f.TransitiveImports())
+
+	f.addFileDependency(flDep)
+	assert.Len(t, f.TransitiveImports(), 2)
 }
 
 func TestFile_Dependents(t *testing.T) {


### PR DESCRIPTION
This patch ensures that the behavior of the `Imports` method on `Entity` is consistent across all entities. `Imports` on `File` was recently updated to include transitive behavior, breaking downstream tools relying on the original behavior. To make sure that `Import` behaves consistently, the prior behavior is returned while a new `TransitiveImports` method has been added to `File`. A later patch will make `Dependents` has a similarly consistent behavior.