### PR TITLE
Makes public interface methods to allow for extensibility

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -47,8 +47,8 @@ type Entity interface {
 	// Primarily, this struct contains the comments associated with the Entity.
 	SourceCodeInfo() SourceCodeInfo
 
-	childAtPath(path []int32) Entity
-	addSourceCodeInfo(info SourceCodeInfo)
+	ChildAtPath(path []int32) Entity
+	AddSourceCodeInfo(info SourceCodeInfo)
 }
 
 // A ParentEntity is any Entity type that can contain messages and/or enums.
@@ -78,8 +78,8 @@ type ParentEntity interface {
 	// DefinedExtensions returns all Extensions defined on this entity.
 	DefinedExtensions() []Extension
 
-	addMessage(m Message)
-	addMapEntry(m Message)
-	addEnum(e Enum)
-	addDefExtension(e Extension)
+	AddMessage(m Message)
+	AddMapEntry(m Message)
+	AddEnum(e Enum)
+	AddDefExtension(e Extension)
 }

--- a/enum.go
+++ b/enum.go
@@ -25,7 +25,7 @@ type Enum interface {
 	Dependents() []Message
 
 	addValue(v EnumValue)
-	addDependent(m Message)
+	AddDependent(m Message)
 	setParent(p ParentEntity)
 }
 
@@ -72,7 +72,7 @@ func (e *enum) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, erro
 	return extension(e.desc.GetOptions(), desc, &ext)
 }
 
-func (e *enum) accept(v Visitor) (err error) {
+func (e *enum) Accept(v Visitor) (err error) {
 	if v == nil {
 		return nil
 	}
@@ -82,7 +82,7 @@ func (e *enum) accept(v Visitor) (err error) {
 	}
 
 	for _, ev := range e.vals {
-		if err = ev.accept(v); err != nil {
+		if err = ev.Accept(v); err != nil {
 			return
 		}
 	}
@@ -90,7 +90,7 @@ func (e *enum) accept(v Visitor) (err error) {
 	return
 }
 
-func (e *enum) addDependent(m Message) {
+func (e *enum) AddDependent(m Message) {
 	e.dependents = append(e.dependents, m)
 }
 
@@ -101,19 +101,19 @@ func (e *enum) addValue(v EnumValue) {
 
 func (e *enum) setParent(p ParentEntity) { e.parent = p }
 
-func (e *enum) childAtPath(path []int32) Entity {
+func (e *enum) ChildAtPath(path []int32) Entity {
 	switch {
 	case len(path) == 0:
 		return e
 	case len(path)%2 != 0:
 		return nil
 	case path[0] == enumTypeValuePath:
-		return e.vals[path[1]].childAtPath(path[2:])
+		return e.vals[path[1]].ChildAtPath(path[2:])
 	default:
 		return nil
 	}
 }
 
-func (e *enum) addSourceCodeInfo(info SourceCodeInfo) { e.info = info }
+func (e *enum) AddSourceCodeInfo(info SourceCodeInfo) { e.info = info }
 
 var _ Enum = (*enum)(nil)

--- a/enum_test.go
+++ b/enum_test.go
@@ -28,7 +28,7 @@ func TestEnum_Syntax(t *testing.T) {
 
 	e := &enum{}
 	f := dummyFile()
-	f.addEnum(e)
+	f.AddEnum(e)
 
 	assert.Equal(t, f.Syntax(), e.Syntax())
 }
@@ -38,7 +38,7 @@ func TestEnum_Package(t *testing.T) {
 
 	e := &enum{}
 	f := dummyFile()
-	f.addEnum(e)
+	f.AddEnum(e)
 
 	assert.NotNil(t, e.Package())
 	assert.Equal(t, f.Package(), e.Package())
@@ -49,7 +49,7 @@ func TestEnum_File(t *testing.T) {
 
 	e := &enum{}
 	m := dummyMsg()
-	m.addEnum(e)
+	m.AddEnum(e)
 
 	assert.NotNil(t, e.File())
 	assert.Equal(t, m.File(), e.File())
@@ -60,7 +60,7 @@ func TestEnum_BuildTarget(t *testing.T) {
 
 	e := &enum{}
 	f := dummyFile()
-	f.addEnum(e)
+	f.AddEnum(e)
 
 	assert.False(t, e.BuildTarget())
 	f.buildTarget = true
@@ -79,7 +79,7 @@ func TestEnum_Parent(t *testing.T) {
 
 	e := &enum{}
 	f := dummyFile()
-	f.addEnum(e)
+	f.AddEnum(e)
 
 	assert.Equal(t, f, e.Parent())
 }
@@ -106,7 +106,7 @@ func TestEnum_Dependents(t *testing.T) {
 
 		e := &enum{}
 		f := dummyFile()
-		f.addEnum(e)
+		f.AddEnum(e)
 
 		assert.Empty(t, e.Dependents())
 	})
@@ -116,7 +116,7 @@ func TestEnum_Dependents(t *testing.T) {
 
 		e := &enum{}
 		m := dummyMsg()
-		m.addEnum(e)
+		m.AddEnum(e)
 
 		assert.Empty(t, e.Dependents())
 	})
@@ -138,7 +138,7 @@ func TestEnum_Dependents(t *testing.T) {
 		e.fqn = fullyQualifiedName(f, e)
 		m := dummyMsg()
 		m.fqn = fullyQualifiedName(f, m)
-		e.addDependent(m)
+		e.AddDependent(m)
 		deps := e.Dependents()
 
 		assert.Len(t, deps, 1)
@@ -159,28 +159,28 @@ func TestEnum_Accept(t *testing.T) {
 	e := &enum{}
 	e.addValue(&enumVal{})
 
-	assert.NoError(t, e.accept(nil))
+	assert.NoError(t, e.Accept(nil))
 
 	v := &mockVisitor{}
-	assert.NoError(t, e.accept(v))
+	assert.NoError(t, e.Accept(v))
 	assert.Equal(t, 1, v.enum)
 	assert.Zero(t, v.enumvalue)
 
 	v.Reset()
 	v.err = errors.New("")
 	v.v = v
-	assert.Error(t, e.accept(v))
+	assert.Error(t, e.Accept(v))
 	assert.Equal(t, 1, v.enum)
 	assert.Zero(t, v.enumvalue)
 
 	v.Reset()
-	assert.NoError(t, e.accept(v))
+	assert.NoError(t, e.Accept(v))
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.enumvalue)
 
 	v.Reset()
 	e.addValue(&mockEnumValue{err: errors.New("")})
-	assert.Error(t, e.accept(v))
+	assert.Error(t, e.Accept(v))
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 2, v.enumvalue)
 }
@@ -189,9 +189,9 @@ func TestEnum_ChildAtPath(t *testing.T) {
 	t.Parallel()
 
 	e := &enum{}
-	assert.Equal(t, e, e.childAtPath(nil))
-	assert.Nil(t, e.childAtPath([]int32{1}))
-	assert.Nil(t, e.childAtPath([]int32{999, 123}))
+	assert.Equal(t, e, e.ChildAtPath(nil))
+	assert.Nil(t, e.ChildAtPath([]int32{1}))
+	assert.Nil(t, e.ChildAtPath([]int32{999, 123}))
 }
 
 type mockEnum struct {
@@ -202,7 +202,7 @@ type mockEnum struct {
 
 func (e *mockEnum) setParent(p ParentEntity) { e.p = p }
 
-func (e *mockEnum) accept(v Visitor) error {
+func (e *mockEnum) Accept(v Visitor) error {
 	_, err := v.VisitEnum(e)
 	if e.err != nil {
 		return e.err
@@ -213,6 +213,6 @@ func (e *mockEnum) accept(v Visitor) error {
 func dummyEnum() *enum {
 	f := dummyFile()
 	e := &enum{desc: &descriptor.EnumDescriptorProto{Name: proto.String("enum")}}
-	f.addEnum(e)
+	f.AddEnum(e)
 	return e
 }

--- a/enum_value.go
+++ b/enum_value.go
@@ -45,7 +45,7 @@ func (ev *enumVal) Extension(desc *proto.ExtensionDesc, ext interface{}) (bool, 
 	return extension(ev.desc.GetOptions(), desc, &ext)
 }
 
-func (ev *enumVal) accept(v Visitor) (err error) {
+func (ev *enumVal) Accept(v Visitor) (err error) {
 	if v == nil {
 		return nil
 	}
@@ -57,13 +57,13 @@ func (ev *enumVal) accept(v Visitor) (err error) {
 
 func (ev *enumVal) setEnum(e Enum) { ev.enum = e }
 
-func (ev *enumVal) childAtPath(path []int32) Entity {
+func (ev *enumVal) ChildAtPath(path []int32) Entity {
 	if len(path) == 0 {
 		return ev
 	}
 	return nil
 }
 
-func (ev *enumVal) addSourceCodeInfo(info SourceCodeInfo) { ev.info = info }
+func (ev *enumVal) AddSourceCodeInfo(info SourceCodeInfo) { ev.info = info }
 
 var _ EnumValue = (*enumVal)(nil)

--- a/enum_value_test.go
+++ b/enum_value_test.go
@@ -94,10 +94,10 @@ func TestEnumVal_Accept(t *testing.T) {
 	t.Parallel()
 
 	ev := &enumVal{}
-	assert.NoError(t, ev.accept(nil))
+	assert.NoError(t, ev.Accept(nil))
 
 	v := &mockVisitor{err: errors.New("")}
-	assert.Error(t, ev.accept(v))
+	assert.Error(t, ev.Accept(v))
 	assert.Equal(t, 1, v.enumvalue)
 }
 
@@ -105,8 +105,8 @@ func TestEnumVal_ChildAtPath(t *testing.T) {
 	t.Parallel()
 
 	ev := &enumVal{}
-	assert.Equal(t, ev, ev.childAtPath(nil))
-	assert.Nil(t, ev.childAtPath([]int32{1}))
+	assert.Equal(t, ev, ev.ChildAtPath(nil))
+	assert.Nil(t, ev.ChildAtPath([]int32{1}))
 }
 
 type mockEnumValue struct {
@@ -117,7 +117,7 @@ type mockEnumValue struct {
 
 func (ev *mockEnumValue) setEnum(e Enum) { ev.e = e }
 
-func (ev *mockEnumValue) accept(v Visitor) error {
+func (ev *mockEnumValue) Accept(v Visitor) error {
 	_, err := v.VisitEnumValue(ev)
 	if ev.err != nil {
 		return ev.err

--- a/extension.go
+++ b/extension.go
@@ -44,7 +44,7 @@ func (e *ext) setMessage(m Message)       {} // noop
 func (e *ext) setOneOf(o OneOf)           {} // noop
 func (e *ext) setExtendee(m Message)      { e.extendee = m }
 
-func (e *ext) accept(v Visitor) (err error) {
+func (e *ext) Accept(v Visitor) (err error) {
 	if v == nil {
 		return
 	}

--- a/extension_test.go
+++ b/extension_test.go
@@ -91,10 +91,10 @@ func TestExt_Accept(t *testing.T) {
 
 	e := &ext{}
 
-	assert.NoError(t, e.accept(nil))
+	assert.NoError(t, e.Accept(nil))
 
 	v := &mockVisitor{err: errors.New("")}
-	assert.Error(t, e.accept(v))
+	assert.Error(t, e.Accept(v))
 	assert.Equal(t, 1, v.extension)
 }
 
@@ -198,7 +198,7 @@ type mockExtension struct {
 	err error
 }
 
-func (e *mockExtension) accept(v Visitor) error {
+func (e *mockExtension) Accept(v Visitor) error {
 	_, err := v.VisitExtension(e)
 	if e.err != nil {
 		return e.err

--- a/field.go
+++ b/field.go
@@ -75,7 +75,7 @@ func (f *field) Extension(desc *proto.ExtensionDesc, ext interface{}) (ok bool, 
 	return extension(f.desc.GetOptions(), desc, &ext)
 }
 
-func (f *field) accept(v Visitor) (err error) {
+func (f *field) Accept(v Visitor) (err error) {
 	if v == nil {
 		return
 	}
@@ -84,13 +84,13 @@ func (f *field) accept(v Visitor) (err error) {
 	return
 }
 
-func (f *field) childAtPath(path []int32) Entity {
+func (f *field) ChildAtPath(path []int32) Entity {
 	if len(path) == 0 {
 		return f
 	}
 	return nil
 }
 
-func (f *field) addSourceCodeInfo(info SourceCodeInfo) { f.info = info }
+func (f *field) AddSourceCodeInfo(info SourceCodeInfo) { f.info = info }
 
 var _ Field = (*field)(nil)

--- a/field_test.go
+++ b/field_test.go
@@ -120,10 +120,10 @@ func TestField_Accept(t *testing.T) {
 
 	f := &field{}
 
-	assert.NoError(t, f.accept(nil))
+	assert.NoError(t, f.Accept(nil))
 
 	v := &mockVisitor{err: errors.New("")}
-	assert.Error(t, f.accept(v))
+	assert.Error(t, f.Accept(v))
 	assert.Equal(t, 1, v.field)
 }
 
@@ -162,8 +162,8 @@ func TestField_ChildAtPath(t *testing.T) {
 	t.Parallel()
 
 	f := &field{}
-	assert.Equal(t, f, f.childAtPath(nil))
-	assert.Nil(t, f.childAtPath([]int32{1}))
+	assert.Equal(t, f, f.ChildAtPath(nil))
+	assert.Nil(t, f.ChildAtPath([]int32{1}))
 }
 
 type mockField struct {
@@ -177,7 +177,7 @@ func (f *mockField) Imports() []File { return f.i }
 
 func (f *mockField) setMessage(m Message) { f.m = m }
 
-func (f *mockField) accept(v Visitor) error {
+func (f *mockField) Accept(v Visitor) error {
 	_, err := v.VisitField(f)
 	if f.err != nil {
 		return f.err

--- a/file.go
+++ b/file.go
@@ -39,15 +39,15 @@ type File interface {
 	// stanza of the file.
 	PackageSourceCodeInfo() SourceCodeInfo
 
-	setPackage(p Package)
+	SetPackage(p Package)
 
-	addFileDependency(fl File)
+	AddFileDependency(fl File)
 
-	addDependent(fl File)
+	AddDependent(fl File)
 
-	addService(s Service)
+	AddService(s Service)
 
-	addPackageSourceCodeInfo(info SourceCodeInfo)
+	AddPackageSourceCodeInfo(info SourceCodeInfo)
 }
 
 type file struct {
@@ -189,7 +189,7 @@ func (f *file) DefinedExtensions() []Extension {
 	return f.defExts
 }
 
-func (f *file) accept(v Visitor) (err error) {
+func (f *file) Accept(v Visitor) (err error) {
 	if v == nil {
 		return nil
 	}
@@ -199,25 +199,25 @@ func (f *file) accept(v Visitor) (err error) {
 	}
 
 	for _, e := range f.enums {
-		if err = e.accept(v); err != nil {
+		if err = e.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, m := range f.msgs {
-		if err = m.accept(v); err != nil {
+		if err = m.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, s := range f.srvs {
-		if err = s.accept(v); err != nil {
+		if err = s.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, ext := range f.defExts {
-		if err = ext.accept(v); err != nil {
+		if err = ext.Accept(v); err != nil {
 			return
 		}
 	}
@@ -225,38 +225,38 @@ func (f *file) accept(v Visitor) (err error) {
 	return
 }
 
-func (f *file) addDefExtension(ext Extension) {
+func (f *file) AddDefExtension(ext Extension) {
 	f.defExts = append(f.defExts, ext)
 }
 
-func (f *file) setPackage(pkg Package) { f.pkg = pkg }
+func (f *file) SetPackage(pkg Package) { f.pkg = pkg }
 
-func (f *file) addEnum(e Enum) {
+func (f *file) AddEnum(e Enum) {
 	e.setParent(f)
 	f.enums = append(f.enums, e)
 }
 
-func (f *file) addFileDependency(fl File) {
+func (f *file) AddFileDependency(fl File) {
 	f.fileDependencies = append(f.fileDependencies, fl)
 }
 
-func (f *file) addDependent(fl File) {
+func (f *file) AddDependent(fl File) {
 	f.dependents = append(f.dependents, fl)
 }
 
-func (f *file) addMessage(m Message) {
+func (f *file) AddMessage(m Message) {
 	m.setParent(f)
 	f.msgs = append(f.msgs, m)
 }
 
-func (f *file) addService(s Service) {
+func (f *file) AddService(s Service) {
 	s.setFile(f)
 	f.srvs = append(f.srvs, s)
 }
 
-func (f *file) addMapEntry(m Message) { panic("cannot add map entry directly to file") }
+func (f *file) AddMapEntry(m Message) { panic("cannot add map entry directly to file") }
 
-func (f *file) childAtPath(path []int32) Entity {
+func (f *file) ChildAtPath(path []int32) Entity {
 	switch {
 	case len(path) == 0:
 		return f
@@ -276,14 +276,14 @@ func (f *file) childAtPath(path []int32) Entity {
 		return nil
 	}
 
-	return child.childAtPath(path[2:])
+	return child.ChildAtPath(path[2:])
 }
 
-func (f *file) addSourceCodeInfo(info SourceCodeInfo) {
+func (f *file) AddSourceCodeInfo(info SourceCodeInfo) {
 	f.syntaxInfo = info
 }
 
-func (f *file) addPackageSourceCodeInfo(info SourceCodeInfo) {
+func (f *file) AddPackageSourceCodeInfo(info SourceCodeInfo) {
 	f.packageInfo = info
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -79,7 +79,7 @@ func TestFile_Enums(t *testing.T) {
 	assert.Empty(t, f.Enums())
 
 	e := &enum{}
-	f.addEnum(e)
+	f.AddEnum(e)
 	assert.Len(t, f.Enums(), 1)
 	assert.Equal(t, e, f.Enums()[0])
 }
@@ -91,10 +91,10 @@ func TestFile_AllEnums(t *testing.T) {
 
 	assert.Empty(t, f.AllEnums())
 
-	f.addEnum(&enum{})
+	f.AddEnum(&enum{})
 	m := &msg{}
-	m.addEnum(&enum{})
-	f.addMessage(m)
+	m.AddEnum(&enum{})
+	f.AddMessage(m)
 
 	assert.Len(t, f.Enums(), 1)
 	assert.Len(t, f.AllEnums(), 2)
@@ -108,7 +108,7 @@ func TestFile_Messages(t *testing.T) {
 	assert.Empty(t, f.Messages())
 
 	m := &msg{}
-	f.addMessage(m)
+	f.AddMessage(m)
 	assert.Len(t, f.Messages(), 1)
 	assert.Equal(t, m, f.Messages()[0])
 }
@@ -117,7 +117,7 @@ func TestFile_MapEntries(t *testing.T) {
 	t.Parallel()
 	f := &file{}
 
-	assert.Panics(t, func() { f.addMapEntry(&msg{}) })
+	assert.Panics(t, func() { f.AddMapEntry(&msg{}) })
 	assert.Empty(t, f.MapEntries())
 }
 
@@ -129,8 +129,8 @@ func TestFile_AllMessages(t *testing.T) {
 	assert.Empty(t, f.AllMessages())
 
 	m := &msg{}
-	m.addMessage(&msg{})
-	f.addMessage(m)
+	m.AddMessage(&msg{})
+	f.AddMessage(m)
 
 	assert.Len(t, f.Messages(), 1)
 	assert.Len(t, f.AllMessages(), 2)
@@ -144,7 +144,7 @@ func TestFile_Services(t *testing.T) {
 	assert.Empty(t, f.Services())
 
 	s := &service{}
-	f.addService(s)
+	f.AddService(s)
 
 	assert.Len(t, f.Services(), 1)
 	assert.Equal(t, s, f.Services()[0])
@@ -157,12 +157,12 @@ func TestFile_Imports(t *testing.T) {
 	nf := &file{desc: &descriptor.FileDescriptorProto{
 		Name: proto.String("foobar"),
 	}}
-	flDep.addFileDependency(nf)
+	flDep.AddFileDependency(nf)
 
 	f := &file{}
 	assert.Empty(t, f.Imports())
 
-	f.addFileDependency(flDep)
+	f.AddFileDependency(flDep)
 	assert.Len(t, f.Imports(), 1)
 }
 
@@ -173,12 +173,12 @@ func TestFile_TransitiveImports(t *testing.T) {
 	nf := &file{desc: &descriptor.FileDescriptorProto{
 		Name: proto.String("foobar"),
 	}}
-	flDep.addFileDependency(nf)
+	flDep.AddFileDependency(nf)
 
 	f := &file{}
 	assert.Empty(t, f.TransitiveImports())
 
-	f.addFileDependency(flDep)
+	f.AddFileDependency(flDep)
 	assert.Len(t, f.TransitiveImports(), 2)
 }
 
@@ -193,13 +193,13 @@ func TestFile_UnusedImports(t *testing.T) {
 		Name: proto.String("i/am/unused.proto"),
 	}}
 
-	target.addFileDependency(unusedFile)
+	target.AddFileDependency(unusedFile)
 
 	publicFile := &file{desc: &descriptor.FileDescriptorProto{
 		Name: proto.String("i/am/public.proto"),
 	}}
 
-	target.addFileDependency(publicFile)
+	target.AddFileDependency(publicFile)
 	target.desc.PublicDependency = append(target.desc.PublicDependency, 1)
 
 	msgDep := dummyMsg()
@@ -210,14 +210,14 @@ func TestFile_UnusedImports(t *testing.T) {
 	fld.addType(ft)
 	m := &msg{}
 	m.addField(fld)
-	target.addMessage(m)
+	target.AddMessage(m)
 
 	mtd := &method{in: msgDep, out: m}
 	svc := &service{}
 	svc.addMethod(mtd)
-	target.addService(svc)
+	target.AddService(svc)
 
-	target.addFileDependency(usedFile)
+	target.AddFileDependency(usedFile)
 
 	unused := target.UnusedImports()
 	assert.Len(t, unused, 1)
@@ -229,7 +229,7 @@ func TestFile_Dependents(t *testing.T) {
 
 	f := &file{}
 	fl := dummyFile()
-	f.addDependent(fl)
+	f.AddDependent(fl)
 	deps := f.Dependents()
 
 	assert.Len(t, deps, 1)
@@ -241,16 +241,16 @@ func TestFile_Accept(t *testing.T) {
 
 	f := &file{}
 
-	assert.Nil(t, f.accept(nil))
+	assert.Nil(t, f.Accept(nil))
 
 	v := &mockVisitor{}
-	assert.NoError(t, f.accept(v))
+	assert.NoError(t, f.Accept(v))
 	assert.Equal(t, 1, v.file)
 
 	v.Reset()
 	v.v = v
 	v.err = errors.New("foo")
-	assert.Equal(t, v.err, f.accept(v))
+	assert.Equal(t, v.err, f.Accept(v))
 	assert.Equal(t, 1, v.file)
 	assert.Zero(t, v.enum)
 	assert.Zero(t, v.message)
@@ -258,11 +258,11 @@ func TestFile_Accept(t *testing.T) {
 	assert.Zero(t, v.extension)
 
 	v.Reset()
-	f.addEnum(&enum{})
-	f.addMessage(&msg{})
-	f.addService(&service{})
-	f.addDefExtension(&ext{})
-	assert.NoError(t, f.accept(v))
+	f.AddEnum(&enum{})
+	f.AddMessage(&msg{})
+	f.AddService(&service{})
+	f.AddDefExtension(&ext{})
+	assert.NoError(t, f.Accept(v))
 	assert.Equal(t, 1, v.file)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.message)
@@ -270,8 +270,8 @@ func TestFile_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.extension)
 
 	v.Reset()
-	f.addDefExtension(&mockExtension{err: errors.New("fizz")})
-	assert.EqualError(t, f.accept(v), "fizz")
+	f.AddDefExtension(&mockExtension{err: errors.New("fizz")})
+	assert.EqualError(t, f.Accept(v), "fizz")
 	assert.Equal(t, 1, v.file)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.message)
@@ -279,8 +279,8 @@ func TestFile_Accept(t *testing.T) {
 	assert.Equal(t, 2, v.extension)
 
 	v.Reset()
-	f.addService(&mockService{err: errors.New("fizz")})
-	assert.EqualError(t, f.accept(v), "fizz")
+	f.AddService(&mockService{err: errors.New("fizz")})
+	assert.EqualError(t, f.Accept(v), "fizz")
 	assert.Equal(t, 1, v.file)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.message)
@@ -288,8 +288,8 @@ func TestFile_Accept(t *testing.T) {
 	assert.Zero(t, v.extension)
 
 	v.Reset()
-	f.addMessage(&mockMessage{err: errors.New("bar")})
-	assert.EqualError(t, f.accept(v), "bar")
+	f.AddMessage(&mockMessage{err: errors.New("bar")})
+	assert.EqualError(t, f.Accept(v), "bar")
 	assert.Equal(t, 1, v.file)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 2, v.message)
@@ -297,8 +297,8 @@ func TestFile_Accept(t *testing.T) {
 	assert.Zero(t, v.extension)
 
 	v.Reset()
-	f.addEnum(&mockEnum{err: errors.New("baz")})
-	assert.EqualError(t, f.accept(v), "baz")
+	f.AddEnum(&mockEnum{err: errors.New("baz")})
+	assert.EqualError(t, f.Accept(v), "baz")
 	assert.Equal(t, 1, v.file)
 	assert.Equal(t, 2, v.enum)
 	assert.Zero(t, v.message)
@@ -323,7 +323,7 @@ func TestFile_DefinedExtensions(t *testing.T) {
 	assert.Empty(t, f.DefinedExtensions())
 
 	ext := &ext{}
-	f.addDefExtension(ext)
+	f.AddDefExtension(ext)
 	assert.Len(t, f.DefinedExtensions(), 1)
 }
 
@@ -338,11 +338,11 @@ type mockFile struct {
 	err error
 }
 
-func (f *mockFile) setPackage(p Package) {
+func (f *mockFile) SetPackage(p Package) {
 	f.pkg = p
 }
 
-func (f *mockFile) accept(v Visitor) error {
+func (f *mockFile) Accept(v Visitor) error {
 	_, err := v.VisitFile(f)
 	if f.err != nil {
 		return f.err
@@ -360,7 +360,7 @@ func dummyFile() *file {
 			Name:    proto.String("file.proto"),
 		},
 	}
-	pkg.addFile(f)
+	pkg.AddFile(f)
 
 	return f
 }

--- a/message.go
+++ b/message.go
@@ -57,7 +57,7 @@ type Message interface {
 	addField(f Field)
 	addExtension(e Extension)
 	addOneOf(o OneOf)
-	addDependent(message Message)
+	AddDependent(message Message)
 	getDependents(set map[string]Message)
 }
 
@@ -190,7 +190,7 @@ func (m *msg) DefinedExtensions() []Extension {
 	return m.defExts
 }
 
-func (m *msg) accept(v Visitor) (err error) {
+func (m *msg) Accept(v Visitor) (err error) {
 	if v == nil {
 		return nil
 	}
@@ -200,31 +200,31 @@ func (m *msg) accept(v Visitor) (err error) {
 	}
 
 	for _, e := range m.enums {
-		if err = e.accept(v); err != nil {
+		if err = e.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, sm := range m.msgs {
-		if err = sm.accept(v); err != nil {
+		if err = sm.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, f := range m.fields {
-		if err = f.accept(v); err != nil {
+		if err = f.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, o := range m.oneofs {
-		if err = o.accept(v); err != nil {
+		if err = o.Accept(v); err != nil {
 			return
 		}
 	}
 
 	for _, ext := range m.defExts {
-		if err = ext.accept(v); err != nil {
+		if err = ext.Accept(v); err != nil {
 			return
 		}
 	}
@@ -236,18 +236,18 @@ func (m *msg) addExtension(ext Extension) {
 	m.exts = append(m.exts, ext)
 }
 
-func (m *msg) addDefExtension(ext Extension) {
+func (m *msg) AddDefExtension(ext Extension) {
 	m.defExts = append(m.defExts, ext)
 }
 
 func (m *msg) setParent(p ParentEntity) { m.parent = p }
 
-func (m *msg) addEnum(e Enum) {
+func (m *msg) AddEnum(e Enum) {
 	e.setParent(m)
 	m.enums = append(m.enums, e)
 }
 
-func (m *msg) addMessage(sm Message) {
+func (m *msg) AddMessage(sm Message) {
 	sm.setParent(m)
 	m.msgs = append(m.msgs, sm)
 }
@@ -262,16 +262,16 @@ func (m *msg) addOneOf(o OneOf) {
 	m.oneofs = append(m.oneofs, o)
 }
 
-func (m *msg) addMapEntry(me Message) {
+func (m *msg) AddMapEntry(me Message) {
 	me.setParent(m)
 	m.maps = append(m.maps, me)
 }
 
-func (m *msg) addDependent(message Message) {
+func (m *msg) AddDependent(message Message) {
 	m.dependents = append(m.dependents, message)
 }
 
-func (m *msg) childAtPath(path []int32) Entity {
+func (m *msg) ChildAtPath(path []int32) Entity {
 	switch {
 	case len(path) == 0:
 		return m
@@ -293,10 +293,10 @@ func (m *msg) childAtPath(path []int32) Entity {
 		return nil
 	}
 
-	return child.childAtPath(path[2:])
+	return child.ChildAtPath(path[2:])
 }
 
-func (m *msg) addSourceCodeInfo(info SourceCodeInfo) { m.info = info }
+func (m *msg) AddSourceCodeInfo(info SourceCodeInfo) { m.info = info }
 
 func messageSetToSlice(name string, set map[string]Message) []Message {
 	dependents := make([]Message, 0, len(set))

--- a/message_test.go
+++ b/message_test.go
@@ -31,7 +31,7 @@ func TestMsg_Syntax(t *testing.T) {
 
 	m := &msg{}
 	f := dummyFile()
-	f.addMessage(m)
+	f.AddMessage(m)
 
 	assert.Equal(t, f.Syntax(), m.Syntax())
 }
@@ -41,7 +41,7 @@ func TestMsg_Package(t *testing.T) {
 
 	m := &msg{}
 	f := dummyFile()
-	f.addMessage(m)
+	f.AddMessage(m)
 
 	assert.NotNil(t, m.Package())
 	assert.Equal(t, f.Package(), m.Package())
@@ -52,7 +52,7 @@ func TestMsg_File(t *testing.T) {
 
 	m := &msg{}
 	pm := dummyMsg()
-	pm.addMessage(m)
+	pm.AddMessage(m)
 
 	assert.NotNil(t, m.File())
 	assert.Equal(t, pm.File(), m.File())
@@ -63,7 +63,7 @@ func TestMsg_BuildTarget(t *testing.T) {
 
 	m := &msg{}
 	f := dummyFile()
-	f.addMessage(m)
+	f.AddMessage(m)
 
 	assert.False(t, m.BuildTarget())
 	f.buildTarget = true
@@ -82,7 +82,7 @@ func TestMsg_Parent(t *testing.T) {
 
 	m := &msg{}
 	pm := dummyMsg()
-	pm.addMessage(m)
+	pm.AddMessage(m)
 
 	assert.Equal(t, pm, m.Parent())
 }
@@ -106,10 +106,10 @@ func TestMsg_Enums(t *testing.T) {
 	assert.Empty(t, m.Enums())
 
 	sm := &msg{}
-	sm.addEnum(&enum{})
-	m.addMessage(sm)
+	sm.AddEnum(&enum{})
+	m.AddMessage(sm)
 
-	m.addEnum(&enum{})
+	m.AddEnum(&enum{})
 	assert.Len(t, m.Enums(), 1)
 }
 
@@ -120,10 +120,10 @@ func TestMsg_AllEnums(t *testing.T) {
 	assert.Empty(t, m.AllEnums())
 
 	sm := &msg{}
-	sm.addEnum(&enum{})
-	m.addMessage(sm)
+	sm.AddEnum(&enum{})
+	m.AddMessage(sm)
 
-	m.addEnum(&enum{})
+	m.AddEnum(&enum{})
 	assert.Len(t, m.AllEnums(), 2)
 }
 
@@ -134,8 +134,8 @@ func TestMsg_Messages(t *testing.T) {
 	assert.Empty(t, m.Messages())
 
 	sm := &msg{}
-	sm.addMessage(&msg{})
-	m.addMessage(sm)
+	sm.AddMessage(&msg{})
+	m.AddMessage(sm)
 
 	assert.Len(t, m.Messages(), 1)
 }
@@ -147,8 +147,8 @@ func TestMsg_AllMessages(t *testing.T) {
 	assert.Empty(t, m.AllMessages())
 
 	sm := &msg{}
-	sm.addMessage(&msg{})
-	m.addMessage(sm)
+	sm.AddMessage(&msg{})
+	m.AddMessage(sm)
 
 	assert.Len(t, m.AllMessages(), 2)
 }
@@ -159,7 +159,7 @@ func TestMsg_MapEntries(t *testing.T) {
 	m := &msg{}
 	assert.Empty(t, m.MapEntries())
 
-	m.addMapEntry(&msg{})
+	m.AddMapEntry(&msg{})
 	assert.Len(t, m.MapEntries(), 1)
 }
 
@@ -235,7 +235,7 @@ func TestMsg_DefinedExtensions(t *testing.T) {
 	assert.Empty(t, m.DefinedExtensions())
 
 	ext := &ext{}
-	m.addDefExtension(ext)
+	m.AddDefExtension(ext)
 	assert.Len(t, m.DefinedExtensions(), 1)
 }
 
@@ -243,16 +243,16 @@ func TestMsg_Accept(t *testing.T) {
 	t.Parallel()
 
 	m := &msg{}
-	m.addMessage(&msg{})
-	m.addEnum(&enum{})
+	m.AddMessage(&msg{})
+	m.AddEnum(&enum{})
 	m.addField(&field{})
 	m.addOneOf(&oneof{})
-	m.addDefExtension(&ext{})
+	m.AddDefExtension(&ext{})
 
-	assert.NoError(t, m.accept(nil))
+	assert.NoError(t, m.Accept(nil))
 
 	v := &mockVisitor{}
-	assert.NoError(t, m.accept(v))
+	assert.NoError(t, m.Accept(v))
 	assert.Equal(t, 1, v.message)
 	assert.Zero(t, v.enum)
 	assert.Zero(t, v.field)
@@ -262,7 +262,7 @@ func TestMsg_Accept(t *testing.T) {
 	v.Reset()
 	v.v = v
 	v.err = errors.New("")
-	assert.Error(t, m.accept(v))
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 1, v.message)
 	assert.Zero(t, v.enum)
 	assert.Zero(t, v.field)
@@ -270,7 +270,7 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Zero(t, v.extension)
 
 	v.Reset()
-	assert.NoError(t, m.accept(v))
+	assert.NoError(t, m.Accept(v))
 	assert.Equal(t, 2, v.message)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.field)
@@ -278,8 +278,8 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Equal(t, 1, v.extension)
 
 	v.Reset()
-	m.addDefExtension(&mockExtension{err: errors.New("")})
-	assert.Error(t, m.accept(v))
+	m.AddDefExtension(&mockExtension{err: errors.New("")})
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 2, v.message)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.field)
@@ -288,7 +288,7 @@ func TestMsg_Accept(t *testing.T) {
 
 	v.Reset()
 	m.addOneOf(&mockOneOf{err: errors.New("")})
-	assert.Error(t, m.accept(v))
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 2, v.message)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 1, v.field)
@@ -297,7 +297,7 @@ func TestMsg_Accept(t *testing.T) {
 
 	v.Reset()
 	m.addField(&mockField{err: errors.New("")})
-	assert.Error(t, m.accept(v))
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 2, v.message)
 	assert.Equal(t, 1, v.enum)
 	assert.Equal(t, 2, v.field)
@@ -305,8 +305,8 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Zero(t, v.extension)
 
 	v.Reset()
-	m.addMessage(&mockMessage{err: errors.New("")})
-	assert.Error(t, m.accept(v))
+	m.AddMessage(&mockMessage{err: errors.New("")})
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 3, v.message)
 	assert.Equal(t, 1, v.enum)
 	assert.Zero(t, v.field)
@@ -314,8 +314,8 @@ func TestMsg_Accept(t *testing.T) {
 	assert.Zero(t, v.extension)
 
 	v.Reset()
-	m.addEnum(&mockEnum{err: errors.New("")})
-	assert.Error(t, m.accept(v))
+	m.AddEnum(&mockEnum{err: errors.New("")})
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 2, v.enum)
 	assert.Equal(t, 1, v.message)
 	assert.Zero(t, v.field)
@@ -355,7 +355,7 @@ func TestMsg_Dependents(t *testing.T) {
 	m := &msg{parent: f}
 	m.fqn = fullyQualifiedName(f, m)
 	m2 := dummyMsg()
-	m.addDependent(m2)
+	m.AddDependent(m2)
 	deps := m.Dependents()
 
 	assert.Len(t, deps, 1)
@@ -366,9 +366,9 @@ func TestMsg_ChildAtPath(t *testing.T) {
 	t.Parallel()
 
 	m := &msg{}
-	assert.Equal(t, m, m.childAtPath(nil))
-	assert.Nil(t, m.childAtPath([]int32{1}))
-	assert.Nil(t, m.childAtPath([]int32{999, 456}))
+	assert.Equal(t, m, m.ChildAtPath(nil))
+	assert.Nil(t, m.ChildAtPath([]int32{1}))
+	assert.Nil(t, m.ChildAtPath([]int32{999, 456}))
 }
 
 func TestMsg_WellKnownType(t *testing.T) {
@@ -376,8 +376,8 @@ func TestMsg_WellKnownType(t *testing.T) {
 	p := &pkg{fd: fd}
 	f := &file{desc: fd}
 	m := &msg{desc: md}
-	f.addMessage(m)
-	p.addFile(f)
+	f.AddMessage(m)
+	p.AddFile(f)
 
 	assert.True(t, m.IsWellKnown())
 	assert.Equal(t, AnyWKT, m.WellKnownType())
@@ -403,7 +403,7 @@ func (m *mockMessage) Imports() []File { return m.i }
 
 func (m *mockMessage) setParent(p ParentEntity) { m.p = p }
 
-func (m *mockMessage) accept(v Visitor) error {
+func (m *mockMessage) Accept(v Visitor) error {
 	_, err := v.VisitMessage(m)
 	if m.err != nil {
 		return m.err
@@ -418,6 +418,6 @@ func dummyMsg() *msg {
 		desc: &descriptor.DescriptorProto{Name: proto.String("message")},
 	}
 
-	f.addMessage(m)
+	f.AddMessage(m)
 	return m
 }

--- a/method.go
+++ b/method.go
@@ -73,7 +73,7 @@ func (m *method) Extension(desc *proto.ExtensionDesc, ext interface{}) (ok bool,
 	return extension(m.desc.GetOptions(), desc, &ext)
 }
 
-func (m *method) accept(v Visitor) (err error) {
+func (m *method) Accept(v Visitor) (err error) {
 	if v == nil {
 		return
 	}
@@ -84,13 +84,13 @@ func (m *method) accept(v Visitor) (err error) {
 
 func (m *method) setService(s Service) { m.service = s }
 
-func (m *method) childAtPath(path []int32) Entity {
+func (m *method) ChildAtPath(path []int32) Entity {
 	if len(path) == 0 {
 		return m
 	}
 	return nil
 }
 
-func (m *method) addSourceCodeInfo(info SourceCodeInfo) { m.info = info }
+func (m *method) AddSourceCodeInfo(info SourceCodeInfo) { m.info = info }
 
 var m Method = (*method)(nil)

--- a/method_test.go
+++ b/method_test.go
@@ -157,10 +157,10 @@ func TestMethod_Accept(t *testing.T) {
 
 	m := &method{}
 
-	assert.Nil(t, m.accept(nil))
+	assert.Nil(t, m.Accept(nil))
 
 	v := &mockVisitor{err: errors.New("foo")}
-	assert.Error(t, m.accept(v))
+	assert.Error(t, m.Accept(v))
 	assert.Equal(t, 1, v.method)
 }
 
@@ -169,8 +169,8 @@ func TestMethod_ChildAtPath(t *testing.T) {
 
 	m := &method{}
 
-	assert.Equal(t, m, m.childAtPath(nil))
-	assert.Nil(t, m.childAtPath([]int32{1}))
+	assert.Equal(t, m, m.ChildAtPath(nil))
+	assert.Nil(t, m.ChildAtPath([]int32{1}))
 }
 
 type mockMethod struct {
@@ -184,7 +184,7 @@ func (m *mockMethod) Imports() []File { return m.i }
 
 func (m *mockMethod) setService(s Service) { m.s = s }
 
-func (m *mockMethod) accept(v Visitor) error {
+func (m *mockMethod) Accept(v Visitor) error {
 	_, err := v.VisitMethod(m)
 	if m.err != nil {
 		return m.err

--- a/node.go
+++ b/node.go
@@ -3,7 +3,7 @@ package pgs
 // Node represents any member of the proto descriptor AST. Typically, the
 // highest level Node is the Package.
 type Node interface {
-	accept(Visitor) error
+	Accept(Visitor) error
 }
 
 // A Visitor exposes methods to walk an AST Node and its children in a depth-
@@ -24,7 +24,7 @@ type Visitor interface {
 }
 
 // Walk applies a depth-first visitor pattern with v against Node n.
-func Walk(v Visitor, n Node) error { return n.accept(v) }
+func Walk(v Visitor, n Node) error { return n.Accept(v) }
 
 type nilVisitor struct{}
 

--- a/node_nilvisitor_test.go
+++ b/node_nilvisitor_test.go
@@ -54,11 +54,11 @@ func enumNode() Node {
 	// }
 
 	sm := &msg{}
-	sm.addEnum(&enum{desc: &descriptor.EnumDescriptorProto{Name: proto.String("Foo")}})
+	sm.AddEnum(&enum{desc: &descriptor.EnumDescriptorProto{Name: proto.String("Foo")}})
 
 	m := &msg{}
-	m.addMessage(sm)
-	m.addEnum(&enum{desc: &descriptor.EnumDescriptorProto{Name: proto.String("Bar")}})
+	m.AddMessage(sm)
+	m.AddEnum(&enum{desc: &descriptor.EnumDescriptorProto{Name: proto.String("Bar")}})
 
 	return m
 }

--- a/node_passvisitor_test.go
+++ b/node_passvisitor_test.go
@@ -54,14 +54,14 @@ func fieldNode() Node {
 	sm.addField(&field{desc: &descriptor.FieldDescriptorProto{Name: proto.String("Foo")}})
 
 	m := &msg{}
-	m.addMessage(sm)
+	m.AddMessage(sm)
 	m.addField(&field{desc: &descriptor.FieldDescriptorProto{Name: proto.String("Bar")}})
 
 	f := &file{}
-	f.addMessage(m)
+	f.AddMessage(m)
 
 	p := &pkg{}
-	p.addFile(f)
+	p.AddFile(f)
 
 	return p
 }

--- a/node_test.go
+++ b/node_test.go
@@ -13,7 +13,7 @@ type mockNode struct {
 	a func(Visitor) error
 }
 
-func (n mockNode) accept(v Visitor) error { return n.a(v) }
+func (n mockNode) Accept(v Visitor) error { return n.a(v) }
 
 func TestWalk(t *testing.T) {
 	t.Parallel()

--- a/oneof.go
+++ b/oneof.go
@@ -32,7 +32,7 @@ type oneof struct {
 	info SourceCodeInfo
 }
 
-func (o *oneof) accept(v Visitor) (err error) {
+func (o *oneof) Accept(v Visitor) (err error) {
 	if v == nil {
 		return
 	}
@@ -81,13 +81,13 @@ func (o *oneof) addField(f Field) {
 	o.flds = append(o.flds, f)
 }
 
-func (o *oneof) childAtPath(path []int32) Entity {
+func (o *oneof) ChildAtPath(path []int32) Entity {
 	if len(path) == 0 {
 		return o
 	}
 	return nil
 }
 
-func (o *oneof) addSourceCodeInfo(info SourceCodeInfo) { o.info = info }
+func (o *oneof) AddSourceCodeInfo(info SourceCodeInfo) { o.info = info }
 
 var _ OneOf = (*oneof)(nil)

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -123,10 +123,10 @@ func TestOneof_Accept(t *testing.T) {
 	t.Parallel()
 
 	o := &oneof{}
-	assert.NoError(t, o.accept(nil))
+	assert.NoError(t, o.Accept(nil))
 
 	v := &mockVisitor{err: errors.New("")}
-	assert.Error(t, o.accept(v))
+	assert.Error(t, o.Accept(v))
 	assert.Equal(t, 1, v.oneof)
 }
 
@@ -134,8 +134,8 @@ func TestOneof_ChildAtPath(t *testing.T) {
 	t.Parallel()
 
 	o := &oneof{}
-	assert.Equal(t, o, o.childAtPath(nil))
-	assert.Nil(t, o.childAtPath([]int32{1}))
+	assert.Equal(t, o, o.ChildAtPath(nil))
+	assert.Nil(t, o.ChildAtPath([]int32{1}))
 }
 
 type mockOneOf struct {
@@ -149,7 +149,7 @@ func (o *mockOneOf) Imports() []File { return o.i }
 
 func (o *mockOneOf) setMessage(m Message) { o.m = m }
 
-func (o *mockOneOf) accept(v Visitor) error {
+func (o *mockOneOf) Accept(v Visitor) error {
 	_, err := v.VisitOneOf(o)
 	if o.err != nil {
 		return o.err

--- a/package.go
+++ b/package.go
@@ -13,9 +13,9 @@ type Package interface {
 	// All the files loaded for this Package
 	Files() []File
 
-	addFile(f File)
+	AddFile(f File)
 
-	setComments(c string)
+	SetComments(c string)
 }
 
 type pkg struct {
@@ -30,7 +30,7 @@ func (p *pkg) Comments() string { return p.comments }
 
 func (p *pkg) Files() []File { return p.files }
 
-func (p *pkg) accept(v Visitor) (err error) {
+func (p *pkg) Accept(v Visitor) (err error) {
 	if v == nil {
 		return nil
 	}
@@ -40,7 +40,7 @@ func (p *pkg) accept(v Visitor) (err error) {
 	}
 
 	for _, f := range p.Files() {
-		if err = f.accept(v); err != nil {
+		if err = f.Accept(v); err != nil {
 			return
 		}
 	}
@@ -48,11 +48,11 @@ func (p *pkg) accept(v Visitor) (err error) {
 	return
 }
 
-func (p *pkg) addFile(f File) {
-	f.setPackage(p)
+func (p *pkg) AddFile(f File) {
+	f.SetPackage(p)
 	p.files = append(p.files, f)
 }
 
-func (p *pkg) setComments(comments string) {
+func (p *pkg) SetComments(comments string) {
 	p.comments = comments
 }

--- a/package_test.go
+++ b/package_test.go
@@ -24,9 +24,9 @@ func TestPkg_Files(t *testing.T) {
 	p := &pkg{}
 	assert.Empty(t, p.Files())
 
-	p.addFile(&file{})
-	p.addFile(&file{})
-	p.addFile(&file{})
+	p.AddFile(&file{})
+	p.AddFile(&file{})
+	p.AddFile(&file{})
 
 	assert.Len(t, p.Files(), 3)
 }
@@ -36,7 +36,7 @@ func TestPkg_AddFile(t *testing.T) {
 
 	p := &pkg{}
 	f := &file{}
-	p.addFile(f)
+	p.AddFile(f)
 	assert.Len(t, p.files, 1)
 	assert.EqualValues(t, f, p.files[0])
 }
@@ -47,28 +47,28 @@ func TestPkg_Accept(t *testing.T) {
 	p := &pkg{
 		files: []File{&mockFile{}},
 	}
-	assert.Nil(t, p.accept(nil))
+	assert.Nil(t, p.Accept(nil))
 
 	v := &mockVisitor{}
-	assert.NoError(t, p.accept(v))
+	assert.NoError(t, p.Accept(v))
 	assert.Equal(t, 1, v.pkg)
 	assert.Zero(t, v.file)
 
 	v.Reset()
 	v.err = errors.New("foobar")
-	assert.EqualError(t, p.accept(v), "foobar")
+	assert.EqualError(t, p.Accept(v), "foobar")
 	assert.Equal(t, 1, v.pkg)
 	assert.Zero(t, v.file)
 
 	v.Reset()
 	v.v = v
-	assert.NoError(t, p.accept(v))
+	assert.NoError(t, p.Accept(v))
 	assert.Equal(t, 1, v.pkg)
 	assert.Equal(t, 1, v.file)
 
 	v.Reset()
-	p.addFile(&mockFile{err: errors.New("fizzbuzz")})
-	assert.EqualError(t, p.accept(v), "fizzbuzz")
+	p.AddFile(&mockFile{err: errors.New("fizzbuzz")})
+	assert.EqualError(t, p.Accept(v), "fizzbuzz")
 	assert.Equal(t, 1, v.pkg)
 	assert.Equal(t, 2, v.file)
 }
@@ -77,7 +77,7 @@ func TestPackage_Comments(t *testing.T) {
 	t.Parallel()
 
 	pkg := dummyPkg()
-	pkg.setComments("foobar")
+	pkg.SetComments("foobar")
 	assert.Equal(t, "foobar", pkg.Comments())
 }
 

--- a/service.go
+++ b/service.go
@@ -68,7 +68,7 @@ func (s *service) addMethod(m Method) {
 	s.methods = append(s.methods, m)
 }
 
-func (s *service) accept(v Visitor) (err error) {
+func (s *service) Accept(v Visitor) (err error) {
 	if v == nil {
 		return
 	}
@@ -78,7 +78,7 @@ func (s *service) accept(v Visitor) (err error) {
 	}
 
 	for _, m := range s.methods {
-		if err = m.accept(v); err != nil {
+		if err = m.Accept(v); err != nil {
 			return
 		}
 	}
@@ -86,19 +86,19 @@ func (s *service) accept(v Visitor) (err error) {
 	return
 }
 
-func (s *service) childAtPath(path []int32) Entity {
+func (s *service) ChildAtPath(path []int32) Entity {
 	switch {
 	case len(path) == 0:
 		return s
 	case len(path)%2 != 0:
 		return nil
 	case path[0] == serviceTypeMethodPath:
-		return s.methods[path[1]].childAtPath(path[2:])
+		return s.methods[path[1]].ChildAtPath(path[2:])
 	default:
 		return nil
 	}
 }
 
-func (s *service) addSourceCodeInfo(info SourceCodeInfo) { s.info = info }
+func (s *service) AddSourceCodeInfo(info SourceCodeInfo) { s.info = info }
 
 var _ Service = (*service)(nil)

--- a/service_test.go
+++ b/service_test.go
@@ -29,7 +29,7 @@ func TestService_Syntax(t *testing.T) {
 
 	s := &service{}
 	f := dummyFile()
-	f.addService(s)
+	f.AddService(s)
 
 	assert.Equal(t, f.Syntax(), s.Syntax())
 }
@@ -39,7 +39,7 @@ func TestService_Package(t *testing.T) {
 
 	s := &service{}
 	f := dummyFile()
-	f.addService(s)
+	f.AddService(s)
 
 	assert.NotNil(t, s.Package())
 	assert.Equal(t, f.Package(), s.Package())
@@ -50,7 +50,7 @@ func TestService_File(t *testing.T) {
 
 	s := &service{}
 	f := dummyFile()
-	f.addService(s)
+	f.AddService(s)
 
 	assert.NotNil(t, s.File())
 	assert.Equal(t, f, s.File())
@@ -61,7 +61,7 @@ func TestService_BuildTarget(t *testing.T) {
 
 	s := &service{}
 	f := dummyFile()
-	f.addService(s)
+	f.AddService(s)
 
 	assert.False(t, s.BuildTarget())
 	f.buildTarget = true
@@ -112,28 +112,28 @@ func TestService_Accept(t *testing.T) {
 	s := &service{}
 	s.addMethod(&method{})
 
-	assert.NoError(t, s.accept(nil))
+	assert.NoError(t, s.Accept(nil))
 
 	v := &mockVisitor{}
-	assert.NoError(t, s.accept(v))
+	assert.NoError(t, s.Accept(v))
 	assert.Equal(t, 1, v.service)
 	assert.Zero(t, v.method)
 
 	v.Reset()
 	v.err = errors.New("fizz")
 	v.v = v
-	assert.Error(t, s.accept(v))
+	assert.Error(t, s.Accept(v))
 	assert.Equal(t, 1, v.service)
 	assert.Zero(t, v.method)
 
 	v.Reset()
-	assert.NoError(t, s.accept(v))
+	assert.NoError(t, s.Accept(v))
 	assert.Equal(t, 1, v.service)
 	assert.Equal(t, 1, v.method)
 
 	v.Reset()
 	s.addMethod(&mockMethod{err: errors.New("buzz")})
-	assert.Error(t, s.accept(v))
+	assert.Error(t, s.Accept(v))
 	assert.Equal(t, 1, v.service)
 	assert.Equal(t, 2, v.method)
 }
@@ -142,9 +142,9 @@ func TestService_ChildAtPath(t *testing.T) {
 	t.Parallel()
 
 	s := &service{}
-	assert.Equal(t, s, s.childAtPath(nil))
-	assert.Nil(t, s.childAtPath([]int32{0}))
-	assert.Nil(t, s.childAtPath([]int32{0, 0}))
+	assert.Equal(t, s, s.ChildAtPath(nil))
+	assert.Nil(t, s.ChildAtPath([]int32{0}))
+	assert.Nil(t, s.ChildAtPath([]int32{0, 0}))
 }
 
 type mockService struct {
@@ -158,7 +158,7 @@ func (s *mockService) Imports() []File { return s.i }
 
 func (s *mockService) setFile(f File) { s.f = f }
 
-func (s *mockService) accept(v Visitor) error {
+func (s *mockService) Accept(v Visitor) error {
 	_, err := v.VisitService(s)
 	if s.err != nil {
 		return s.err
@@ -175,6 +175,6 @@ func dummyService() *service {
 		},
 	}
 
-	f.addService(s)
+	f.AddService(s)
 	return s
 }


### PR DESCRIPTION
I need to be able to extend some PGS types but doing so is difficult due to the fact that they are interfaces which rely upon interfaces that have private methods.

I am not certain that this is the best avenue to take to achieve the desired outcome. Being able to extend the underlying structs would probably yield a cleaner API. However, this is the least disruptive approach and may be more ideal, given that it doesn't pollute the API as much as publicizing the structs may.

I'm pretty sure I got them all, except `Artifact` :: `artifact()`.