### PR TITLE
Makes repeated & map fields with embedded messages behave the same as embedded fields

### DIFF
--- a/field_type.go
+++ b/field_type.go
@@ -150,6 +150,8 @@ type repT struct {
 func (r *repT) IsRepeated() bool       { return true }
 func (r *repT) Element() FieldTypeElem { return r.el }
 
+func (r *repT) IsEmbed() bool { return r.el.IsEmbed() }
+
 func (r *repT) Imports() []File { return r.el.Imports() }
 
 func (r *repT) toElem() FieldTypeElem { panic("cannot convert repeated FieldType to FieldTypeElem") }

--- a/field_type.go
+++ b/field_type.go
@@ -151,7 +151,9 @@ func (r *repT) IsRepeated() bool       { return true }
 func (r *repT) Element() FieldTypeElem { return r.el }
 
 func (r *repT) IsEmbed() bool { return r.el.IsEmbed() }
-
+func (r *repT) Embed() Message {
+	return r.el.Embed()
+}
 func (r *repT) Imports() []File { return r.el.Imports() }
 
 func (r *repT) toElem() FieldTypeElem { panic("cannot convert repeated FieldType to FieldTypeElem") }


### PR DESCRIPTION
`IsEmbed` currently reports `false` and `Embed` returns nil if the field is also repeated or a map. This pull request changes that behavior.`IsEmbed` and `Embed` have been updated to check the `FieldTypeElement`.

This breaks a number of tests and may be one of those things that has to stay the way it is for backward compatibility. If it breaks your tests, it could cause more issues downstream with implementations relying on pgs.

I can resolve the issues but there is no point in doing so if the change is deemed to have too much potential adverse consequence. On the other hand, it may be better to address it now while the API is advertised as being unstable.