### PR TITLE
build: make the ci work again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ testdata-graph: bin/protoc-gen-debug # parses the proto file sets in testdata/gr
 	done
 
 testdata/generated: protoc-gen-go bin/protoc-gen-example
-	which protoc-gen-go || (go install github.com/golang/protobuf/protoc-gen-go)
+	which protoc-gen-go || (go install github.com/golang/protobuf/protoc-gen-go@v1.3.5)
 	rm -rf ./testdata/generated && mkdir -p ./testdata/generated
 	# generate the official go code, must be one directory at a time
 	set -e; for subdir in `find ./testdata/protos -type d -mindepth 1`; do \
@@ -83,7 +83,7 @@ vendor: # install project dependencies
 
 .PHONY: protoc-gen-go
 protoc-gen-go:
-	which protoc-gen-go || (go get -u github.com/golang/protobuf/protoc-gen-go)
+	which protoc-gen-go || (go get -u github.com/golang/protobuf/protoc-gen-go@v1.3.5)
 
 bin/protoc-gen-example: # creates the demo protoc plugin for demonstrating uses of PG*
 	go build -o ./bin/protoc-gen-example ./testdata/protoc-gen-example


### PR DESCRIPTION
While this project didn't receive many updates, the Go and Protobuf
community were evolving and they decided to move the development from
the being under to Go's umbrella to be on the Protobuf's. They also
decided to make the original project in github.com/golang/protobuf just
a wrapper around the new project located in
github.com/protocolbuffers/protobuf-go. This made it possible to include
a lot of fixed but at the same time a lot of breaking changes were
included.

Pinning to a version before doing this major bump on the Golang Protobuf
API (they coined as APIv2) solved the issue.

More info.: https://blog.golang.org/protobuf-apiv2