### PR TITLE
Update +build to go:build

### DIFF
--- a/lang/go/type_name_p2_presence_test.go
+++ b/lang/go/type_name_p2_presence_test.go
@@ -1,3 +1,4 @@
+//go:build !proto3_presence
 // +build !proto3_presence
 
 package pgsgo

--- a/lang/go/type_name_p3_presence_test.go
+++ b/lang/go/type_name_p3_presence_test.go
@@ -1,3 +1,4 @@
+//go:build proto3_presence
 // +build proto3_presence
 
 package pgsgo

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
`make lint` has been failing on the old `// +build` directives.