### PR TITLE
Remove reference to github.com/golang/protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/lyft/protoc-gen-star/v2
 go 1.17
 
 require (
-	github.com/golang/protobuf v1.5.2
 	github.com/spf13/afero v1.3.3
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/tools v0.1.12

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/message_test.go
+++ b/message_test.go
@@ -2,13 +2,13 @@ package pgs
 
 import (
 	"errors"
+	"google.golang.org/protobuf/reflect/protodesc"
 	"testing"
 
-	desc "github.com/golang/protobuf/descriptor"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 	descriptor "google.golang.org/protobuf/types/descriptorpb"
+	any "google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestMsg_Name(t *testing.T) {
@@ -418,7 +418,9 @@ func TestMsg_ChildAtPath(t *testing.T) {
 }
 
 func TestMsg_WellKnownType(t *testing.T) {
-	fd, md := desc.ForMessage(&any.Any{})
+	d := (&any.Any{}).ProtoReflect().Descriptor()
+	fd := protodesc.ToFileDescriptorProto(d.ParentFile())
+	md := protodesc.ToDescriptorProto(d)
 	p := &pkg{fd: fd}
 	f := &file{desc: fd}
 	m := &msg{desc: md}

--- a/message_test.go
+++ b/message_test.go
@@ -2,11 +2,11 @@ package pgs
 
 import (
 	"errors"
-	"google.golang.org/protobuf/reflect/protodesc"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
 	descriptor "google.golang.org/protobuf/types/descriptorpb"
 	any "google.golang.org/protobuf/types/known/anypb"
 )

--- a/tools.go
+++ b/tools.go
@@ -4,5 +4,5 @@
 package tools
 
 import (
-	_ "github.com/golang/protobuf/protoc-gen-go"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
There was an errant reference to the old [github.com/golang/protobuf](http://github.com/golang/protobuf) package, which https://github.com/lyft/protoc-gen-star/pull/113 aimed to remove. I missed that pg*’s go.mod still had that package.