### PR TITLE
ci(lint): enable errorlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
+    - errorlint
     - goconst
     - gocyclo
     - gofmt
@@ -11,12 +11,10 @@ linters:
     - ineffassign
     - misspell
     - revive
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
 issues:
   max-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
Also remove deadcode, structcheck and varcheck as they are deprecated and replaced by unused

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>