### PR TITLE
Update linters and golangci-lint version; correct linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,29 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
-    - goconst
-    - gocyclo
+    - errcheck
     - gofmt
     - goimports
+    - gosec
     - gosimple
     - govet
     - ineffassign
     - misspell
+    - nakedret
     - revive
-    - structcheck
+    - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+linters-settings:
+  gosec:
+    excludes:
+      - G306
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true
 issues:
   max-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - errorlint
     - gofmt
     - goimports
     - gosec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_language_version:
-  python: python3.8
+  python: python3.10
 repos:
   -   repo: https://github.com/golangci/golangci-lint
-      rev: v1.42.1
+      rev: v1.55.0
       hooks:
         -   id: golangci-lint

--- a/debug_test.go
+++ b/debug_test.go
@@ -334,10 +334,10 @@ func TestPrefixedDebugger_Assert(t *testing.T) {
 	}
 
 	d := rootDebugger{fail: fail}.Push("FIZZ")
-	d.Assert(1 == 1, "fizz")
+	d.Assert(true, "fizz")
 	assert.False(t, failed)
 
-	d.Assert(1 == 0, "foo")
+	d.Assert(false, "foo")
 	assert.True(t, failed)
 }
 

--- a/enum_test.go
+++ b/enum_test.go
@@ -150,7 +150,7 @@ func TestEnum_Extension(t *testing.T) {
 	// cannot be parallel
 
 	e := &enum{desc: &descriptor.EnumDescriptorProto{}}
-	assert.NotPanics(t, func() { e.Extension(nil, nil) })
+	assert.NotPanics(t, func() { e.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestEnum_Accept(t *testing.T) {

--- a/enum_value_test.go
+++ b/enum_value_test.go
@@ -87,7 +87,7 @@ func TestEnumVal_Extension(t *testing.T) {
 	// cannot be parallel
 
 	ev := &enumVal{desc: &descriptor.EnumValueDescriptorProto{}}
-	assert.NotPanics(t, func() { ev.Extension(nil, nil) })
+	assert.NotPanics(t, func() { ev.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestEnumVal_Accept(t *testing.T) {

--- a/field_test.go
+++ b/field_test.go
@@ -164,7 +164,7 @@ func TestField_Extension(t *testing.T) {
 	// cannot be parallel
 
 	f := &field{desc: &descriptor.FieldDescriptorProto{}}
-	assert.NotPanics(t, func() { f.Extension(nil, nil) })
+	assert.NotPanics(t, func() { f.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestField_Accept(t *testing.T) {

--- a/file.go
+++ b/file.go
@@ -195,34 +195,34 @@ func (f *file) accept(v Visitor) (err error) {
 	}
 
 	if v, err = v.VisitFile(f); err != nil || v == nil {
-		return
+		return err
 	}
 
 	for _, e := range f.enums {
 		if err = e.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, m := range f.msgs {
 		if err = m.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, s := range f.srvs {
 		if err = s.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, ext := range f.defExts {
 		if err = ext.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
-	return
+	return err
 }
 
 func (f *file) addDefExtension(ext Extension) {

--- a/file_test.go
+++ b/file_test.go
@@ -312,7 +312,7 @@ func TestFile_Extension(t *testing.T) {
 	assert.NotPanics(t, func() {
 		(&file{
 			desc: &descriptor.FileDescriptorProto{},
-		}).Extension(nil, nil)
+		}).Extension(nil, nil) //nolint:errcheck
 	})
 }
 

--- a/init_option_test.go
+++ b/init_option_test.go
@@ -28,7 +28,7 @@ func TestDebugEnv(t *testing.T) {
 	g := &Generator{}
 	assert.False(t, g.debug)
 
-	e := strconv.Itoa(rand.Int())
+	e := strconv.Itoa(rand.Int()) //nolint:gosec
 
 	DebugEnv(e)(g)
 	assert.False(t, g.debug)

--- a/lang/go/package.go
+++ b/lang/go/package.go
@@ -68,7 +68,7 @@ func (c context) optionPackage(e pgs.Entity) (path, pkg string) {
 		if idx := strings.LastIndex(pkg, "/"); idx > -1 {
 			pkg = pkg[idx+1:]
 		}
-		return
+		return path, pkg
 	}
 
 	// check if there's a go_package option specified
@@ -82,26 +82,26 @@ func (c context) optionPackage(e pgs.Entity) (path, pkg string) {
 		} else { // no other info, then replace all non-alphanumerics from the input file name
 			pkg = nonAlphaNumPattern.ReplaceAllString(e.File().InputPath().BaseName(), "_")
 		}
-		return
+		return path, pkg
 	}
 
 	// go_package="example.com/foo/bar;baz" should have a package name of `baz`
 	if idx := strings.LastIndex(pkg, ";"); idx > -1 {
 		path = pkg[:idx]
 		pkg = nonAlphaNumPattern.ReplaceAllString(pkg[idx+1:], "_")
-		return
+		return path, pkg
 	}
 
 	// go_package="example.com/foo/bar" should have a package name of `bar`
 	if idx := strings.LastIndex(pkg, "/"); idx > -1 {
 		path = pkg
 		pkg = nonAlphaNumPattern.ReplaceAllString(pkg[idx+1:], "_")
-		return
+		return path, pkg
 	}
 
 	pkg = nonAlphaNumPattern.ReplaceAllString(pkg, "_")
 
-	return
+	return path, pkg
 }
 
 func (c context) resolveGoPackageOption(e pgs.Entity) string {

--- a/message.go
+++ b/message.go
@@ -225,40 +225,40 @@ func (m *msg) accept(v Visitor) (err error) {
 	}
 
 	if v, err = v.VisitMessage(m); err != nil || v == nil {
-		return
+		return err
 	}
 
 	for _, e := range m.enums {
 		if err = e.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, sm := range m.msgs {
 		if err = sm.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, f := range m.fields {
 		if err = f.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, o := range m.oneofs {
 		if err = o.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
 	for _, ext := range m.defExts {
 		if err = ext.accept(v); err != nil {
-			return
+			return err
 		}
 	}
 
-	return
+	return nil
 }
 
 func (m *msg) addExtension(ext Extension) {

--- a/message_test.go
+++ b/message_test.go
@@ -260,7 +260,7 @@ func TestMsg_SyntheticOneOfFields_And_RealOneOfs(t *testing.T) {
 func TestMsg_Extension(t *testing.T) {
 	// cannot be parallel
 	m := &msg{desc: &descriptor.DescriptorProto{}}
-	assert.NotPanics(t, func() { m.Extension(nil, nil) })
+	assert.NotPanics(t, func() { m.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestMsg_Extensions(t *testing.T) {

--- a/method_test.go
+++ b/method_test.go
@@ -149,7 +149,7 @@ func TestMethod_Extension(t *testing.T) {
 	// cannot be parallel
 
 	m := &method{desc: &descriptor.MethodDescriptorProto{}}
-	assert.NotPanics(t, func() { m.Extension(nil, nil) })
+	assert.NotPanics(t, func() { m.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestMethod_Accept(t *testing.T) {

--- a/name.go
+++ b/name.go
@@ -68,7 +68,7 @@ func (n Name) Split() (parts []string) {
 			parts[1] = "_" + parts[1]
 			return parts[1:]
 		}
-		return
+		return parts
 	default: // camelCase
 		buf := &bytes.Buffer{}
 		var capt, lodash, num bool
@@ -104,7 +104,7 @@ func (n Name) Split() (parts []string) {
 			buf.WriteRune(r)
 		}
 		parts = append(parts, buf.String())
-		return
+		return parts
 	}
 }
 

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -106,7 +106,7 @@ func TestOneof_Extension(t *testing.T) {
 	// cannot be parallel
 
 	o := &oneof{desc: &descriptor.OneofDescriptorProto{}}
-	assert.NotPanics(t, func() { o.Extension(nil, nil) })
+	assert.NotPanics(t, func() { o.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestOneof_Fields(t *testing.T) {

--- a/persister_test.go
+++ b/persister_test.go
@@ -182,7 +182,7 @@ func TestPersister_Persist_GeneratorTemplateAppend(t *testing.T) {
 	assert.Equal(t, "", resp.File[3].GetName())
 	assert.Equal(t, "quux", resp.File[3].GetContent())
 
-	resp = p.Persist(GeneratorTemplateAppend{
+	_ = p.Persist(GeneratorTemplateAppend{
 		FileName: "doesNotExist",
 		TemplateArtifact: TemplateArtifact{
 			Template: genTpl,

--- a/protoc-gen-debug/main.go
+++ b/protoc-gen-debug/main.go
@@ -38,7 +38,7 @@ func main() {
 		log.Fatal("unable to create output dir: ", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(path, "code_generator_request.pb.bin"), data, 0644)
+	err = os.WriteFile(filepath.Join(path, "code_generator_request.pb.bin"), data, 0644)
 	if err != nil {
 		log.Fatal("unable to write request to disk: ", err)
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -79,7 +79,7 @@ func TestService_Extension(t *testing.T) {
 	// cannot be parallel
 
 	s := &service{desc: &descriptor.ServiceDescriptorProto{}}
-	assert.NotPanics(t, func() { s.Extension(nil, nil) })
+	assert.NotPanics(t, func() { s.Extension(nil, nil) }) //nolint:errcheck
 }
 
 func TestService_Imports(t *testing.T) {


### PR DESCRIPTION
Building on requested change to add `errorlint` in https://github.com/lyft/protoc-gen-star/pull/124/files