### PR TITLE
Add Dependency info to supplement Dependents

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -468,9 +468,20 @@ func assignDependent(ft FieldType, parent Message) {
 		if ft.IsMap() {
 			if ft.Key().IsEnum() {
 				ft.Key().Enum().addDependent(parent)
-			} else if ft.Key().IsEmbed() {
+			}
+			if ft.Key().IsEmbed() {
 				ft.Key().Embed().addDependent(parent)
 				parent.addDependency(ft.Embed())
+			}
+			if ft.Element().IsEmbed() {
+				ft.Element().Embed().addDependent(parent)
+				parent.addDependency(ft.Element().Embed())
+			}
+		}
+
+		if ft.IsRepeated() {
+			if ft.Element().IsEmbed() {
+				parent.addDependency(ft.Element().Embed())
 			}
 		}
 	}

--- a/ast.go
+++ b/ast.go
@@ -456,11 +456,13 @@ func assignDependent(ft FieldType, parent Message) {
 		ft.Enum().addDependent(parent)
 	} else if ft.IsEmbed() {
 		ft.Embed().addDependent(parent)
+		parent.addDependency(ft.Embed())
 	} else if ft.IsRepeated() || ft.IsMap() {
 		if ft.Element().IsEnum() {
 			ft.Element().Enum().addDependent(parent)
 		} else if ft.Element().IsEmbed() {
 			ft.Element().Embed().addDependent(parent)
+			parent.addDependency(ft.Embed())
 		}
 
 		if ft.IsMap() {
@@ -468,6 +470,7 @@ func assignDependent(ft FieldType, parent Message) {
 				ft.Key().Enum().addDependent(parent)
 			} else if ft.Key().IsEmbed() {
 				ft.Key().Embed().addDependent(parent)
+				parent.addDependency(ft.Embed())
 			}
 		}
 	}

--- a/message.go
+++ b/message.go
@@ -210,6 +210,11 @@ func (m *msg) populateDependentsCache() {
 	}
 }
 
+func (m *msg) Dependents() []Message {
+	m.populateDependentsCache()
+	return messageSetToSlice(m.FullyQualifiedName(), m.dependentsCache)
+}
+
 func (m *msg) getDependencies(set map[string]Message) {
 	m.populateDependenciesCache()
 
@@ -228,11 +233,6 @@ func (m *msg) populateDependenciesCache() {
 		m.dependenciesCache[dep.FullyQualifiedName()] = dep
 		dep.getDependencies(m.dependenciesCache)
 	}
-}
-
-func (m *msg) Dependents() []Message {
-	m.populateDependentsCache()
-	return messageSetToSlice(m.FullyQualifiedName(), m.dependentsCache)
 }
 
 func (m *msg) Dependencies() []Message {

--- a/message.go
+++ b/message.go
@@ -48,6 +48,10 @@ type Message interface {
 	// transitively used.
 	Dependents() []Message
 
+	// Dependencies returns all of the messages that message directly or
+	// transitively uses.
+	Dependencies() []Message
+
 	// IsMapEntry identifies this message as a MapEntry. If true, this message is
 	// not generated as code, and is used exclusively when marshaling a map field
 	// to the wire format.
@@ -68,6 +72,8 @@ type Message interface {
 	addOneOf(o OneOf)
 	addDependent(message Message)
 	getDependents(set map[string]Message)
+	addDependency(message Message)
+	getDependencies(set map[string]Message)
 }
 
 type msg struct {
@@ -84,6 +90,8 @@ type msg struct {
 	maps                []Message
 	dependents          []Message
 	dependentsCache     map[string]Message
+	dependencies        []Message
+	dependenciesCache   map[string]Message
 
 	info SourceCodeInfo
 }
@@ -202,9 +210,34 @@ func (m *msg) populateDependentsCache() {
 	}
 }
 
+func (m *msg) getDependencies(set map[string]Message) {
+	m.populateDependenciesCache()
+
+	for fqn, d := range m.dependenciesCache {
+		set[fqn] = d
+	}
+}
+
+func (m *msg) populateDependenciesCache() {
+	if m.dependenciesCache != nil {
+		return
+	}
+
+	m.dependenciesCache = map[string]Message{}
+	for _, dep := range m.dependencies {
+		m.dependenciesCache[dep.FullyQualifiedName()] = dep
+		dep.getDependencies(m.dependenciesCache)
+	}
+}
+
 func (m *msg) Dependents() []Message {
 	m.populateDependentsCache()
 	return messageSetToSlice(m.FullyQualifiedName(), m.dependentsCache)
+}
+
+func (m *msg) Dependencies() []Message {
+	m.populateDependenciesCache()
+	return messageSetToSlice(m.FullyQualifiedName(), m.dependenciesCache)
 }
 
 func (m *msg) Extension(desc *protoimpl.ExtensionInfo, ext interface{}) (bool, error) {
@@ -298,6 +331,12 @@ func (m *msg) addMapEntry(me Message) {
 
 func (m *msg) addDependent(message Message) {
 	m.dependents = append(m.dependents, message)
+}
+
+func (m *msg) addDependency(message Message) {
+	if message != nil {
+		m.dependencies = append(m.dependencies, message)
+	}
 }
 
 func (m *msg) childAtPath(path []int32) Entity {

--- a/message_test.go
+++ b/message_test.go
@@ -408,6 +408,29 @@ func TestMsg_Dependents(t *testing.T) {
 	assert.Contains(t, deps, m2)
 }
 
+func TestMsg_Dependencies(t *testing.T) {
+	t.Parallel()
+
+	pkg := dummyPkg()
+	f := &file{
+		pkg: pkg,
+		desc: &descriptor.FileDescriptorProto{
+			Package: proto.String(pkg.ProtoName().String()),
+			Syntax:  proto.String(string(Proto3)),
+			Name:    proto.String("test_file.proto"),
+		},
+	}
+
+	m := &msg{parent: f}
+	m.fqn = fullyQualifiedName(f, m)
+	m2 := dummyMsg()
+	m2.addDependency(m)
+	deps := m2.Dependencies()
+
+	assert.Len(t, deps, 1)
+	assert.Contains(t, deps, m)
+}
+
 func TestMsg_ChildAtPath(t *testing.T) {
 	t.Parallel()
 

--- a/message_test.go
+++ b/message_test.go
@@ -420,15 +420,22 @@ func TestMsg_Dependencies(t *testing.T) {
 			Name:    proto.String("test_file.proto"),
 		},
 	}
+	m1 := &msg{parent: f}
+	m1.fqn = "test.m1"
+	m2 := &msg{parent: f}
+	m2.fqn = "test.m2"
+	m3 := &msg{parent: f}
+	m3.fqn = "test.m3"
 
-	m := &msg{parent: f}
-	m.fqn = fullyQualifiedName(f, m)
-	m2 := dummyMsg()
-	m2.addDependency(m)
-	deps := m2.Dependencies()
+	m2.addDependency(m1)
+	m3.addDependency(m2)
 
-	assert.Len(t, deps, 1)
-	assert.Contains(t, deps, m)
+	assert.Len(t, m2.Dependencies(), 1)
+	assert.Contains(t, m2.Dependencies(), m1)
+
+	assert.Len(t, m3.Dependencies(), 2)
+	assert.Contains(t, m3.Dependencies(), m1)
+	assert.Contains(t, m3.Dependencies(), m2)
 }
 
 func TestMsg_ChildAtPath(t *testing.T) {


### PR DESCRIPTION
While parsing and assigning dependencies, we can store both directions
of dependency information. This allows simple resolution from a message
-> all messages within its definition.
